### PR TITLE
ci/auto version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,4 @@ jobs:
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           git push --follow-tags
 
-      - uses: softprops/action-gh-release@v2
-        if: steps.bump.outputs.bump != 'none'
-        with:
-          generate_release_notes: true
+


### PR DESCRIPTION
- **ci: fix npm version dirty working directory issue**
- **ci: fix git identity and optimize workflow order**
- **ci: adopt mature auto-release workflow from conventional commits template**
- **ci: update package-lock.json**
- **ci: use RELEASE_TOKEN to bypass branch protection**
- **ci: remove stale tag before npm version to handle partial runs**
- **ci: remove GitHub Release step, only bump + tag**
