### PR TITLE
feat: surface WAV import and recording errors via toast notifications

### DIFF
--- a/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
@@ -85,6 +85,32 @@ export function isWavFile(arrayBuffer: ArrayBuffer): boolean
 
 校验 `RIFF`(0-3)+ `WAVE`(8-11)魔数,与 `parseWav` 的检查保持一致。
 
+**原理**
+
+魔数(magic number)是文件开头固定的标识字节序列,用作文件类型的"指纹"。WAV 属于 RIFF 容器格式,头部布局:
+
+```
+偏移 0-3:  "RIFF"   RIFF 容器标识
+偏移 4-7:  文件大小 (小端 uint32,本函数不读取)
+偏移 8-11: "WAVE"   具体容器格式
+```
+
+`isWavFile` 只在 `ArrayBuffer` 上创建 `Uint8Array` 视图(零拷贝),取字节 0-3 与 8-11 各转成 ASCII 字符串后逐一比较:
+
+```ts
+const uint8 = new Uint8Array(arrayBuffer, 0, 12)
+const riff = String.fromCharCode(...uint8.subarray(0, 4))
+const wave = String.fromCharCode(...uint8.subarray(8, 12))
+return riff === 'RIFF' && wave === 'WAVE'
+```
+
+- **为什么双魔数?** `RIFF` 是通用容器(RIFF 家族还包括 `AVI `、`WEBP` 等),`WAVE` 才指明是音频;只查 `RIFF` 会把 AVI 视频误判为 WAV。
+- **字节序无关:** 魔数字符串按字节顺序直接比较,不受小端/大端影响(字节序只影响偏移 4-7 的长度字段)。
+- **与 `parseWav` 一致:** 使用与其开头两个断言 (`wav-parser.ts` 的 `Not a RIFF file` / `Not a WAV file`) 完全相同的检查,故校验通过后 `parseWav` 不会抛这两类错误。
+- **边界:** `byteLength < 12` 直接返回 `false`,避免越界读取。
+
+**为什么预校验而非仅靠 try/catch:** 提前拦截可给用户更具体的提示(「不支持的文件格式」),且避免对非 WAV 文件做无谓的完整解析。
+
 ### `src/hooks/useAnalysis.ts` 改动
 
 `handleFileChange`:

--- a/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
@@ -28,9 +28,52 @@ interface Toast {
 
 ### Toast 组件 — `src/components/Toast.tsx` + `Toast.module.css`
 
-- 订阅 store,右上角 fixed 定位(视觉参考 TipWidget 的 fixed + CSS 变量)
-- error 类型用红色系视觉区分,每条带关闭按钮
-- 挂载在 `AnalysisPage.tsx`(`<TipWidget />` 旁)
+纯渲染组件,零业务逻辑,只订阅 store 并渲染。挂载在 `AnalysisPage.tsx`(`<TipWidget />` 旁)。
+
+**组件 API**
+
+```tsx
+export function Toast(): JSX.Element | null
+```
+
+无 props。内部通过 `useToastStore((s) => s.toasts)` 和 `useToastStore((s) => s.dismissToast)`
+订阅,Zustand selector 保证只在 toasts 变化时重渲染。
+
+**渲染行为**
+
+- `toasts.length === 0` 时返回 `null`(不渲染 DOM)
+- 否则渲染根容器 `<div className={styles.stack} aria-live="polite">`,内部每一条:
+  ```tsx
+  <div role="alert" className={`${styles.toast} ${toast.type === 'error' ? styles.error : ''}`}>
+    <span className={styles.message}>{toast.message}</span>
+    <button className={styles.close} onClick={() => dismissToast(toast.id)} aria-label="关闭提示">×</button>
+  </div>
+  ```
+- `key={toast.id}` 复用现有 DOM;新 toast 通过 CSS 动画 `toast-in` 滑入
+
+**视觉规范** — `Toast.module.css`
+
+| 元素 | 规格 |
+|---|---|
+| 容器 `.stack` | `position: fixed; top: 24px; right: 24px; z-index: 50`,flex 纵向堆叠,`gap: 8px`,`max-width: 320px`,`pointer-events: none` |
+| 单条 `.toast` | 白色面板(`--panel`),`--border` 边框,左边框 4px 主题色(`--info`),圆角 `--radius`,`--shadow-hover` 阴影,`pointer-events: auto` |
+| error 变体 `.error` | 左边框改 `#E23E57`(与图表 F1 红色一致) |
+| 消息 `.message` | `font-size: 13px`, `line-height: 1.5`, `color: var(--text)` |
+| 关闭按钮 `.close` | 20×20 透明按钮,悬停 `#F3F4F6` 背景 + `--text` 前景 |
+| 移动端 `@media (max-width: 768px)` | 容器 `top/right/left: 12px`,铺满宽度 |
+
+全部 CSS 变量均取自 `css/style.css` 已有的 `--panel/--border/--info/--radius/--shadow-hover/--text` 等。
+
+**无障碍**
+
+- 容器 `aria-live="polite"`:新 toast 出现时屏幕阅读器播报,不打断用户
+- 每条 `role="alert"`:语义化标识为提醒内容
+- 关闭按钮带 `aria-label="关闭提示"`(无可见文字)
+
+**交互**
+
+- 自动消失:由 store 的 3s 定时器触发,组件本身不持有定时器
+- 手动关闭:点击 `×` 调 `dismissToast(id)`
 
 ### WAV 魔数预校验 — `src/dsp/wav-parser.ts`
 

--- a/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-wav-import-error-feedback-design.md
@@ -1,0 +1,73 @@
+# WAV 导入错误反馈 + Toast 通知组件
+
+## 问题
+
+文件选择框 `accept=".wav"` 仅是文件选择器的筛选提示,用户仍可选择任意文件。
+`useAnalysis.handleFileChange` 调用 `parseWav`,非 WAV 文件会抛出异常,
+但 `catch` 块仅 `console.error`,用户无任何反馈(静默失败)。
+
+## 方案
+
+新增一个通用的 Toast 通知组件,并让 WAV 导入/录音错误通过它反馈给用户。
+
+### Toast store — `src/store/toastStore.ts`
+
+遵循现有 appStore 模式(Zustand,直接 `getState().action()` 可测)。
+
+```ts
+interface Toast {
+  id: number
+  type: 'error' | 'success' | 'info'
+  message: string
+}
+```
+
+- `showToast(type, message)` — 追加一条,setTimeout 3s 后自动 dismiss
+- `dismissToast(id)` — 手动关闭
+- 顶层固定栈,最多同时显示 4 条
+
+### Toast 组件 — `src/components/Toast.tsx` + `Toast.module.css`
+
+- 订阅 store,右上角 fixed 定位(视觉参考 TipWidget 的 fixed + CSS 变量)
+- error 类型用红色系视觉区分,每条带关闭按钮
+- 挂载在 `AnalysisPage.tsx`(`<TipWidget />` 旁)
+
+### WAV 魔数预校验 — `src/dsp/wav-parser.ts`
+
+新增导出纯函数:
+
+```ts
+export function isWavFile(arrayBuffer: ArrayBuffer): boolean
+```
+
+校验 `RIFF`(0-3)+ `WAVE`(8-11)魔数,与 `parseWav` 的检查保持一致。
+
+### `src/hooks/useAnalysis.ts` 改动
+
+`handleFileChange`:
+1. `parseWav` 前魔数预校验失败 → `showToast('error', '不支持的文件格式,请选择 .wav 文件')` 并提前 return
+2. `catch` 块按 `err.message` 映射为友好中文提示(见下)
+3. 10s 超限的 `alert()` 改为 `showToast('error', ...)`
+
+`onRecord` 的 catch 也改为 toast:「无法启动录音,请检查麦克风权限」。
+
+### 错误消息映射
+
+| parseWav 抛错 | 用户提示 |
+|---|---|
+| `Not a RIFF file` / `Not a WAV file` | 格式不支持 |
+| `fmt chunk not found` / `data chunk not found` | 文件已损坏 |
+| `Unsupported bitsPerSample` | 不支持的编码(仅支持 8/16/24/32 位 PCM) |
+| 其他 | 导入失败 |
+
+### 测试
+
+- `src/__tests__/toastStore.test.ts` — 直接测 show/dismiss/自动超时(vi.useFakeTimers)
+- `src/__tests__/dsp/wav-parser.test.js` — `isWavFile` 合法/非法/空 buffer
+- `src/__tests__/AnalysisPage.test.tsx` 或 useAnalysis 测试 — 导入非法文件 → toast store 出现错误条目
+
+### 范围
+
+- 仅新增 toast 通知 + WAV 导入/录音错误反馈
+- 不引入第三方 toast 库
+- 不改动 parseWav 本身

--- a/src/__tests__/Toast.test.tsx
+++ b/src/__tests__/Toast.test.tsx
@@ -21,21 +21,27 @@ describe('Toast', () => {
   })
 
   it('renders toasts from the store with role=alert', () => {
-    useToastStore.getState().showToast('error', '仅支持 WAV 格式')
+    act(() => {
+      useToastStore.getState().showToast('error', '仅支持 WAV 格式')
+    })
     render(<Toast />)
     const alert = screen.getByRole('alert')
     expect(alert.textContent).toContain('仅支持 WAV 格式')
   })
 
   it('applies the error variant class for error toasts', () => {
-    useToastStore.getState().showToast('error', '出错了')
+    act(() => {
+      useToastStore.getState().showToast('error', '出错了')
+    })
     render(<Toast />)
     const alert = screen.getByRole('alert')
     expect(alert.className).toContain(styles.error)
   })
 
   it('dismisses a toast when its close button is clicked', () => {
-    useToastStore.getState().showToast('info', '关闭我')
+    act(() => {
+      useToastStore.getState().showToast('info', '关闭我')
+    })
     render(<Toast />)
     fireEvent.click(screen.getByRole('button', { name: '关闭提示' }))
     expect(useToastStore.getState().toasts).toHaveLength(0)
@@ -43,7 +49,9 @@ describe('Toast', () => {
 
   it('clears a toast automatically after the store timeout elapses', () => {
     vi.useFakeTimers()
-    useToastStore.getState().showToast('info', '自动消失')
+    act(() => {
+      useToastStore.getState().showToast('info', '自动消失')
+    })
     render(<Toast />)
     expect(screen.getByText('自动消失')).toBeTruthy()
 

--- a/src/__tests__/Toast.test.tsx
+++ b/src/__tests__/Toast.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import { Toast } from '../components/Toast'
+import { useToastStore } from '../store/toastStore'
+import styles from '../components/Toast.module.css'
+
+function resetStore() {
+  useToastStore.setState({ toasts: [] })
+}
+
+describe('Toast', () => {
+  afterEach(() => {
+    resetStore()
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when there are no toasts', () => {
+    resetStore()
+    const { container } = render(<Toast />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders toasts from the store with role=alert', () => {
+    useToastStore.getState().showToast('error', '仅支持 WAV 格式')
+    render(<Toast />)
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toContain('仅支持 WAV 格式')
+  })
+
+  it('applies the error variant class for error toasts', () => {
+    useToastStore.getState().showToast('error', '出错了')
+    render(<Toast />)
+    const alert = screen.getByRole('alert')
+    expect(alert.className).toContain(styles.error)
+  })
+
+  it('dismisses a toast when its close button is clicked', () => {
+    useToastStore.getState().showToast('info', '关闭我')
+    render(<Toast />)
+    fireEvent.click(screen.getByRole('button', { name: '关闭提示' }))
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('clears a toast automatically after the store timeout elapses', () => {
+    vi.useFakeTimers()
+    useToastStore.getState().showToast('info', '自动消失')
+    render(<Toast />)
+    expect(screen.getByText('自动消失')).toBeTruthy()
+
+    act(() => vi.advanceTimersByTime(3000))
+    expect(screen.queryByText('自动消失')).toBeNull()
+  })
+})

--- a/src/__tests__/dsp/wav-parser.test.js
+++ b/src/__tests__/dsp/wav-parser.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 import assert from 'node:assert/strict'
-import { parseWav } from '../../dsp/wav-parser'
+import { parseWav, isWavFile } from '../../dsp/wav-parser'
 
 function makeWav({ sampleRate = 44100, numChannels = 1, bitsPerSample = 16, samples = null }) {
   const bytesPerSample = bitsPerSample / 8
@@ -174,5 +174,32 @@ describe('parseWav', () => {
   it('throws for unsupported bitsPerSample', () => {
     const samples = new Float32Array(10)
     assert.throws(() => parseWav(makeWav({ sampleRate: 44100, bitsPerSample: 64, samples })), /Unsupported/)
+  })
+})
+
+describe('isWavFile', () => {
+  it('returns true for a valid WAV buffer', () => {
+    assert.equal(isWavFile(makeWav({})), true)
+  })
+
+  it('returns false for a non-RIFF buffer', () => {
+    const buf = new ArrayBuffer(44)
+    assert.equal(isWavFile(buf), false)
+  })
+
+  it('returns false for a RIFF buffer that is not WAVE', () => {
+    const buf = new ArrayBuffer(12)
+    const view = new DataView(buf)
+    let off = 0
+    const w = (s) => { for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i)); off += s.length }
+    w('RIFF')
+    view.setUint32(off, 4, true); off += 4
+    w('AVI ')
+    assert.equal(isWavFile(buf), false)
+  })
+
+  it('returns false for a too-short buffer', () => {
+    const buf = new ArrayBuffer(4)
+    assert.equal(isWavFile(buf), false)
   })
 })

--- a/src/__tests__/toastStore.test.ts
+++ b/src/__tests__/toastStore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useToastStore } from '../store/toastStore'
+
+function resetStore() {
+  useToastStore.setState({ toasts: [] })
+}
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    resetStore()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('showToast', () => {
+    it('adds a toast with auto-incrementing id', () => {
+      useToastStore.getState().showToast('error', 'first')
+      const id1 = useToastStore.getState().toasts[0].id
+      useToastStore.getState().showToast('info', 'second')
+      const id2 = useToastStore.getState().toasts[1].id
+      const toasts = useToastStore.getState().toasts
+      expect(toasts).toHaveLength(2)
+      expect(toasts[0]).toMatchObject({ id: id1, type: 'error', message: 'first' })
+      expect(toasts[1]).toMatchObject({ id: id2, type: 'info', message: 'second' })
+      expect(id2).toBe(id1 + 1)
+    })
+
+    it('auto-dismisses a toast after 3 seconds', () => {
+      useToastStore.getState().showToast('error', 'bye')
+      expect(useToastStore.getState().toasts).toHaveLength(1)
+
+      vi.advanceTimersByTime(3000)
+      expect(useToastStore.getState().toasts).toHaveLength(0)
+    })
+
+    it('keeps toasts within the stack limit', () => {
+      for (let i = 0; i < 6; i++) {
+        useToastStore.getState().showToast('info', `msg-${i}`)
+      }
+      expect(useToastStore.getState().toasts).toHaveLength(4)
+    })
+  })
+
+  describe('dismissToast', () => {
+    it('removes a toast by id', () => {
+      useToastStore.getState().showToast('error', 'one')
+      const id1 = useToastStore.getState().toasts[0].id
+      useToastStore.getState().showToast('info', 'two')
+      useToastStore.getState().dismissToast(id1)
+      const toasts = useToastStore.getState().toasts
+      expect(toasts).toHaveLength(1)
+      expect(toasts[0].message).toBe('two')
+    })
+  })
+})

--- a/src/__tests__/useAnalysis.test.tsx
+++ b/src/__tests__/useAnalysis.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAnalysis } from '../hooks/useAnalysis'
+import { useToastStore } from '../store/toastStore'
+import { useAppStore } from '../store/appStore'
+import { recordingBuffer } from '../audio/recordingBuffer'
+
+if (typeof File.prototype.arrayBuffer !== 'function') {
+  File.prototype.arrayBuffer = function () {
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as ArrayBuffer)
+      reader.onerror = () => reject(reader.error)
+      reader.readAsArrayBuffer(this)
+    })
+  }
+}
+
+function resetStores() {
+  useAppStore.getState().reset()
+  useToastStore.setState({ toasts: [] })
+  recordingBuffer.clear()
+}
+
+describe('useAnalysis import error feedback', () => {
+  beforeEach(() => resetStores())
+  afterEach(() => resetStores())
+
+  it('shows an error toast when importing a non-WAV file', async () => {
+    const { result } = renderHook(() => useAnalysis())
+
+    const nonWav = new ArrayBuffer(64)
+    new Uint8Array(nonWav).set([0x50, 0x4b, 0x03, 0x04], 0) // "PK\x03\x04" (ZIP magic)
+
+    await act(async () => {
+      await result.current.handleFileChange({
+        target: { files: [new File([nonWav], 'test.zip')] },
+      } as unknown as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].type).toBe('error')
+    expect(toasts[0].message).toContain('.wav')
+  })
+
+  it('shows an error toast for a corrupted WAV buffer', async () => {
+    const { result } = renderHook(() => useAnalysis())
+
+    const corrupt = new ArrayBuffer(64)
+    new Uint8Array(corrupt).set([0x52, 0x49, 0x46, 0x46], 0) // RIFF
+    new Uint8Array(corrupt).set([0x57, 0x41, 0x56, 0x45], 8) // WAVE
+
+    await act(async () => {
+      await result.current.handleFileChange({
+        target: { files: [new File([corrupt], 'bad.wav')] },
+      } as unknown as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].type).toBe('error')
+  })
+
+  it('does not add frames when import fails', async () => {
+    const { result } = renderHook(() => useAnalysis())
+
+    const nonWav = new ArrayBuffer(64)
+    await act(async () => {
+      await result.current.handleFileChange({
+        target: { files: [new File([nonWav], 'test.txt')] },
+      } as unknown as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    expect(useAppStore.getState().frames).toEqual([])
+  })
+})

--- a/src/components/Toast.module.css
+++ b/src/components/Toast.module.css
@@ -1,0 +1,80 @@
+.stack {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 320px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--info);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-hover);
+  pointer-events: auto;
+  animation: toast-in .2s ease;
+}
+
+.toast.error {
+  border-left-color: #E23E57;
+}
+
+.message {
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.close {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-mute);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  padding: 0;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+
+.close:hover {
+  background: #F3F4F6;
+  color: var(--text);
+}
+
+@keyframes toast-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .stack {
+    top: 12px;
+    right: 12px;
+    left: 12px;
+    max-width: none;
+  }
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,30 @@
+import { useToastStore } from '../store/toastStore'
+import styles from './Toast.module.css'
+
+export function Toast() {
+  const toasts = useToastStore((s) => s.toasts)
+  const dismissToast = useToastStore((s) => s.dismissToast)
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className={styles.stack} aria-live="polite">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role="alert"
+          className={`${styles.toast} ${toast.type === 'error' ? styles.error : ''}`}
+        >
+          <span className={styles.message}>{toast.message}</span>
+          <button
+            className={styles.close}
+            onClick={() => dismissToast(toast.id)}
+            aria-label="关闭提示"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/dsp/index.ts
+++ b/src/dsp/index.ts
@@ -1,7 +1,7 @@
 export { RingBuffer } from './RingBuffer'
 export { Complex } from './complex'
 export { complexFft, ifft, fftMagnitudes } from './fft'
-export { parseWav } from './wav-parser'
+export { parseWav, isWavFile } from './wav-parser'
 export type { WavResult } from './wav-parser'
 export { Resampler } from './resampler'
 export { VoiceActivityDetector, DEFAULT_VAD_THRESHOLD } from './vad'

--- a/src/dsp/wav-parser.ts
+++ b/src/dsp/wav-parser.ts
@@ -28,6 +28,14 @@ function readSample(view: DataView, offset: number, bitsPerSample: number, audio
   }
 }
 
+export function isWavFile(arrayBuffer: ArrayBuffer): boolean {
+  if (arrayBuffer.byteLength < 12) return false
+  const uint8 = new Uint8Array(arrayBuffer, 0, 12)
+  const riff = String.fromCharCode(...uint8.subarray(0, 4))
+  const wave = String.fromCharCode(...uint8.subarray(8, 12))
+  return riff === 'RIFF' && wave === 'WAVE'
+}
+
 export function parseWav(arrayBuffer: ArrayBuffer): WavResult {
   const view = new DataView(arrayBuffer)
   const uint8 = new Uint8Array(arrayBuffer, 0, 4)

--- a/src/hooks/useAnalysis.ts
+++ b/src/hooks/useAnalysis.ts
@@ -1,9 +1,24 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useAppStore } from '../store/appStore'
+import { useToastStore } from '../store/toastStore'
 import { getAudioEngine } from '../ts'
 import { recordingBuffer } from '../audio/recordingBuffer'
-import { AnalysisPipeline, parseWav, Resampler } from '../dsp'
+import { AnalysisPipeline, parseWav, isWavFile, Resampler } from '../dsp'
 import type { AnalysisFrame } from '../types'
+
+function importErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : ''
+  if (/Not a RIFF file|Not a WAV file/.test(message)) {
+    return '不支持的文件格式，请选择 .wav 文件。'
+  }
+  if (/chunk not found/.test(message)) {
+    return '文件已损坏或不是有效的 WAV 文件。'
+  }
+  if (/Unsupported bitsPerSample/.test(message)) {
+    return '不支持的编码，仅支持 8/16/24/32 位 PCM。'
+  }
+  return '导入失败，请检查文件后重试。'
+}
 
 export function useAnalysis() {
   const pipelineRef = useRef<InstanceType<typeof AnalysisPipeline> | null>(null)
@@ -88,6 +103,7 @@ export function useAnalysis() {
       setIsRequesting(false)
     } catch (err) {
       console.error('Failed to start recording:', err)
+      useToastStore.getState().showToast('error', '无法启动录音,请检查麦克风权限。')
       setIsRequesting(false)
     }
   }, [isCapturing, isRequesting, stopRecording, onAudioChunk])
@@ -116,6 +132,11 @@ export function useAnalysis() {
     try {
       const buf = await file.arrayBuffer()
 
+      if (!isWavFile(buf)) {
+        useToastStore.getState().showToast('error', '不支持的文件格式，请选择 .wav 文件。')
+        return
+      }
+
       stopRecording(false)
 
       const parsed = parseWav(buf)
@@ -129,7 +150,7 @@ export function useAnalysis() {
 
       const maxSamples = 16000 * 10
       if (samples.length > maxSamples) {
-        alert('导入的音频不能超过 10 秒，请裁剪后重试。')
+        useToastStore.getState().showToast('error', '导入的音频不能超过 10 秒，请裁剪后重试。')
         return
       }
 
@@ -151,6 +172,7 @@ export function useAnalysis() {
       frameOffsetRef.current = 0
     } catch (err) {
       console.error('WAV import failed:', err)
+      useToastStore.getState().showToast('error', importErrorMessage(err))
     } finally {
       if (fileInputRef.current) {
         fileInputRef.current.value = ''

--- a/src/hooks/useAnalysis.ts
+++ b/src/hooks/useAnalysis.ts
@@ -132,12 +132,12 @@ export function useAnalysis() {
     try {
       const buf = await file.arrayBuffer()
 
+      stopRecording(false)
+
       if (!isWavFile(buf)) {
         useToastStore.getState().showToast('error', '不支持的文件格式，请选择 .wav 文件。')
         return
       }
-
-      stopRecording(false)
 
       const parsed = parseWav(buf)
       let samples = parsed.samples

--- a/src/routes/AnalysisPage.tsx
+++ b/src/routes/AnalysisPage.tsx
@@ -9,6 +9,7 @@ import { ConfigDrawer } from '../components/ConfigDrawer'
 import { HelpDrawer } from '../components/HelpDrawer'
 import { AboutModal } from '../components/AboutModal'
 import { TipWidget } from '../components/TipWidget'
+import { Toast } from '../components/Toast'
 import styles from './AnalysisPage.module.css'
 
 const LEGEND_KEYS = ['f0', 'f1', 'f2'] as const
@@ -97,6 +98,8 @@ export function AnalysisPage() {
       </main>
 
       <TipWidget />
+
+      <Toast />
 
       <ConfigDrawer open={configOpen} onClose={() => setConfigOpen(false)} />
       <HelpDrawer open={helpOpen} onClose={() => setHelpOpen(false)} />

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand'
+
+export type ToastType = 'error' | 'success' | 'info'
+
+export interface Toast {
+  id: number
+  type: ToastType
+  message: string
+}
+
+const TOAST_DURATION = 3000
+const MAX_TOASTS = 4
+
+interface ToastState {
+  toasts: Toast[]
+  showToast: (type: ToastType, message: string) => void
+  dismissToast: (id: number) => void
+}
+
+let nextId = 1
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+
+  showToast: (type, message) => {
+    const id = nextId++
+    set((state) => ({
+      toasts: [...state.toasts, { id, type, message }].slice(-MAX_TOASTS),
+    }))
+
+    window.setTimeout(() => {
+      if (get().toasts.some((t) => t.id === id)) {
+        get().dismissToast(id)
+      }
+    }, TOAST_DURATION)
+  },
+
+  dismissToast: (id) => set((state) => ({
+    toasts: state.toasts.filter((t) => t.id !== id),
+  })),
+}))


### PR DESCRIPTION
- add toastStore + Toast component (top-right stack, auto-dismiss)
- add isWavFile magic-byte precheck, map parseWav errors to user messages
- replace alert() for >10s, toast on record start failure
- mount Toast in AnalysisPage