### PR TITLE
feat:add hit target feedback

### DIFF
--- a/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
+++ b/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
@@ -585,3 +585,573 @@ Expected: build succeeds, `dist/` produced.
 
 Run: `git status --short` and `git log --oneline -8`
 Expected: all work committed, clean status.
+
+---
+
+# 修订计划（2026-08-01）：常驻显示 + 同侧下方布局 + F0/F1/F2 实时数值
+
+> 用户需求变更：1) 反馈卡片常驻显示（不再无数据时消失）；2) 位置移到 TargetPresetBar 同侧（左侧）正下方；3) 卡片显示 F0/F1/F2 实时具体数值。汇总行「完美/提示」保留。更新后的 spec：`docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md`。
+
+**修订目标：** FeedbackCard 常驻显示，含 F0/F1/F2 实时数值行（命中绿/偏低偏高橙/无数据 `--` 灰，不带文字），保留汇总行；布局改为左侧容器包裹 TargetPresetBar + FeedbackCard。
+
+---
+
+### Task 7: getFormantStatus 共享判定函数（TDD）
+
+**Files:**
+- Create: `src/feedback/status.ts`
+- Test: `src/__tests__/status.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/status.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { getFormantStatus } from '../feedback/status'
+
+describe('getFormantStatus', () => {
+  it('returns hit when value is inside range', () => {
+    expect(getFormantStatus(300, [200, 400])).toBe('hit')
+  })
+
+  it('returns hit when value equals lower bound', () => {
+    expect(getFormantStatus(200, [200, 400])).toBe('hit')
+  })
+
+  it('returns hit when value equals upper bound', () => {
+    expect(getFormantStatus(400, [200, 400])).toBe('hit')
+  })
+
+  it('returns low when value is below lower bound', () => {
+    expect(getFormantStatus(100, [200, 400])).toBe('low')
+  })
+
+  it('returns high when value is above upper bound', () => {
+    expect(getFormantStatus(500, [200, 400])).toBe('high')
+  })
+
+  it('returns none for null', () => {
+    expect(getFormantStatus(null, [200, 400])).toBe('none')
+  })
+
+  it('returns none for undefined', () => {
+    expect(getFormantStatus(undefined, [200, 400])).toBe('none')
+  })
+
+  it('returns none for non-finite value', () => {
+    expect(getFormantStatus(NaN, [200, 400])).toBe('none')
+    expect(getFormantStatus(Infinity, [200, 400])).toBe('none')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/status.test.ts`
+Expected: FAIL — `Cannot find module '../feedback/status'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/feedback/status.ts`:
+
+```ts
+export type FormantStatus = 'hit' | 'low' | 'high' | 'none'
+
+export function getFormantStatus(
+  value: number | null | undefined,
+  range: [number, number],
+): FormantStatus {
+  if (value == null || !Number.isFinite(value)) return 'none'
+  if (value < range[0]) return 'low'
+  if (value > range[1]) return 'high'
+  return 'hit'
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/status.test.ts`
+Expected: 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feedback/status.ts src/__tests__/status.test.ts
+git commit -m "feat(feedback): add getFormantStatus shared evaluator"
+```
+
+---
+
+### Task 8: 重构 evaluateHitRate 复用 getFormantStatus
+
+**Files:**
+- Modify: `src/feedback/hitRate.ts`
+- Test: `src/__tests__/hitRate.test.ts`
+
+- [ ] **Step 1: Refactor implementation to use getFormantStatus**
+
+Modify `src/feedback/hitRate.ts` — replace the inline boundary checks with the shared function:
+
+```ts
+import type { FeedbackContext, FeedbackResult } from '../types'
+import { getFormantStatus } from './status'
+
+const KEYS = ['f0', 'f1', 'f2'] as const
+
+export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
+  const { latestFrame, bands } = ctx
+  if (!latestFrame) return null
+
+  const hints: string[] = []
+  let hasData = false
+  let allHit = true
+
+  for (const k of KEYS) {
+    const status = getFormantStatus(latestFrame[k], bands[k].range)
+    if (status === 'none') continue
+    hasData = true
+    if (status === 'low') {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏低`)
+    } else if (status === 'high') {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏高`)
+    }
+  }
+
+  if (!hasData) return null
+  if (allHit) {
+    return { id: 'hit-rate', label: '目标区间', status: 'hit', message: '完美' }
+  }
+  return { id: 'hit-rate', label: '目标区间', status: 'miss', message: hints.join(' ') }
+}
+```
+
+- [ ] **Step 2: Run existing hitRate tests to verify behavior unchanged**
+
+Run: `npx vitest run src/__tests__/hitRate.test.ts`
+Expected: 7 tests PASS (no behavior change).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/feedback/hitRate.ts
+git commit -m "refactor(feedback): reuse getFormantStatus in evaluateHitRate"
+```
+
+---
+
+### Task 9: FeedbackCard 常驻显示 + 实时数值行（TDD）
+
+**Files:**
+- Modify: `src/components/FeedbackCard.tsx`
+- Modify: `src/components/FeedbackCard.module.css`
+- Test: `src/__tests__/FeedbackCard.test.tsx`
+
+- [ ] **Step 1: Rewrite the failing test**
+
+Modify `src/__tests__/FeedbackCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeedbackCard } from '../components/FeedbackCard'
+import { useAppStore } from '../store/appStore'
+import { VOWEL_PRESETS } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function setFrame(f0: number | null, f1: number | null, f2: number | null) {
+  useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
+}
+
+const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+
+describe('FeedbackCard', () => {
+  beforeEach(() => {
+    useAppStore.getState().reset()
+  })
+
+  it('renders header even with no data', () => {
+    render(<FeedbackCard />)
+    expect(screen.getByText('实时反馈')).toBeTruthy()
+  })
+
+  it('shows -- placeholders for values when no data', () => {
+    render(<FeedbackCard />)
+    expect(screen.getAllByText('--')).toHaveLength(3)
+  })
+
+  it('shows real-time F0/F1/F2 values in Hz', () => {
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText(`${mid(vowelA.f0[0], vowelA.f0[1])} Hz`)).toBeTruthy()
+    expect(screen.getByText(`${mid(vowelA.f1[0], vowelA.f1[1])} Hz`)).toBeTruthy()
+    expect(screen.getByText(`${mid(vowelA.f2[0], vowelA.f2[1])} Hz`)).toBeTruthy()
+  })
+
+  it('marks value rows with correct data-status', () => {
+    const midF0 = mid(vowelA.f0[0], vowelA.f0[1])
+    setFrame(midF0, vowelA.f1[0] - 50, vowelA.f2[1] + 100)
+    render(<FeedbackCard />)
+    const container = document.querySelector('aside')!
+    const rows = Array.from(container.querySelectorAll('[data-status]'))
+    const rowByLabel = (label: string) =>
+      rows.find(r => r.firstChild?.textContent === label) as HTMLElement
+    expect(rowByLabel('F0').dataset.status).toBe('hit')
+    expect(rowByLabel('F1').dataset.status).toBe('low')
+    expect(rowByLabel('F2').dataset.status).toBe('high')
+  })
+
+  it('renders summary row with 完美 when all hit', () => {
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText('目标区间')).toBeTruthy()
+    expect(screen.getByText('完美')).toBeTruthy()
+  })
+
+  it('renders summary row with deviation hints when miss', () => {
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    render(<FeedbackCard />)
+    expect(screen.getByText('F2偏高')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: FAIL — current component returns null on no data, no value rows.
+
+- [ ] **Step 3: Rewrite minimal implementation**
+
+Modify `src/components/FeedbackCard.tsx`:
+
+```tsx
+import { useAppStore } from '../store/appStore'
+import { useFeedback } from '../feedback'
+import { getFormantStatus } from '../feedback/status'
+import type { FormantStatus } from '../feedback/status'
+import styles from './FeedbackCard.module.css'
+
+const KEYS = ['f0', 'f1', 'f2'] as const
+type FormantKey = typeof KEYS[number]
+
+const STATUS_CLASS: Record<FormantStatus, string> = {
+  hit: styles.valueHit,
+  low: styles.valueWarn,
+  high: styles.valueWarn,
+  none: styles.valueMute,
+}
+
+function formatValue(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '--'
+  return `${Math.round(value)} Hz`
+}
+
+export function FeedbackCard() {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
+  const results = useFeedback()
+
+  return (
+    <aside className={styles.card} aria-label="实时反馈">
+      <div className={styles.header}>实时反馈</div>
+      <div className={styles.values}>
+        {KEYS.map(key => {
+          const status = getFormantStatus(latestFrame?.[key], bands[key].range)
+          return (
+            <div key={key} className={styles.valueRow} data-status={status}>
+              <span className={styles.valueLabel}>{key.toUpperCase()}</span>
+              <span className={`${styles.valueNum} ${STATUS_CLASS[status]}`}>
+                {formatValue(latestFrame?.[key])}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+      <ul className={styles.list}>
+        {results.map(result => (
+          <li
+            key={result.id}
+            className={styles.row}
+            data-status={result.status}
+          >
+            <span className={styles.label}>{result.label}</span>
+            <span
+              className={`${styles.value} ${result.status === 'hit' ? styles.valueHit : ''}`}
+            >
+              {result.message}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}
+```
+
+- [ ] **Step 4: Update CSS module**
+
+Modify `src/components/FeedbackCard.module.css` — add value-row styles, keep existing summary styles. Note `.card` positioning will be changed in Task 10:
+
+```css
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  box-shadow: var(--shadow-card);
+}
+.header {
+  font-size: 12px;
+  color: var(--text-soft);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+.values {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px dashed var(--border);
+  margin-top: 12px;
+  padding-top: 12px;
+}
+.valueRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.valueLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-soft);
+  min-width: 20px;
+}
+.valueNum {
+  font-size: 15px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.valueHit {
+  color: var(--hit);
+}
+.valueWarn {
+  color: var(--warn);
+}
+.valueMute {
+  color: var(--text-mute);
+}
+.list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px dashed var(--border);
+  padding-top: 12px;
+}
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.label {
+  font-size: 11px;
+  color: var(--text-soft);
+}
+.value {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-mute);
+}
+.row[data-status="hit"] .value {
+  color: var(--hit);
+  animation: pulseGlow 1.6s ease-out infinite;
+}
+.row[data-status="miss"] .value {
+  color: var(--warn);
+}
+
+@keyframes pulseGlow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(16, 185, 129, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row[data-status="hit"] .value {
+    animation: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .card {
+    width: 100%;
+    margin-bottom: 14px;
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: 6 tests PASS.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/FeedbackCard.tsx src/components/FeedbackCard.module.css src/__tests__/FeedbackCard.test.tsx
+git commit -m "feat(feedback): always-on card with real-time F0/F1/F2 values"
+```
+
+---
+
+### Task 10: 布局改为左侧容器包裹
+
+**Files:**
+- Modify: `src/routes/AnalysisPage.tsx`
+- Modify: `src/routes/AnalysisPage.module.css`
+- Modify: `src/components/TargetPresetBar.module.css`
+- Modify: `src/components/FeedbackCard.module.css`
+
+- [ ] **Step 1: Modify `AnalysisPage.tsx`**
+
+Wrap `TargetPresetBar` and `FeedbackCard` in a side panel container. Change the current `<main>` block:
+
+```tsx
+<main className={styles.content}>
+  <div className={styles.sidePanel}>
+    <TargetPresetBar />
+    <FeedbackCard />
+  </div>
+
+  <div className={styles.chartsColumn}>
+    ...
+  </div>
+</main>
+```
+
+- [ ] **Step 2: Add `.sidePanel` to `AnalysisPage.module.css`**
+
+Add:
+
+```css
+.sidePanel {
+  position: absolute;
+  top: 16px;
+  right: calc(50% + 466px);
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 768px) {
+  .sidePanel {
+    position: static;
+    width: 100%;
+    margin-bottom: 14px;
+  }
+}
+```
+
+Merge the `.sidePanel` media query into the existing `@media (max-width: 768px)` block.
+
+- [ ] **Step 3: Modify `TargetPresetBar.module.css`**
+
+Remove absolute positioning from `.bar` (the side panel now positions it). `.bar` becomes:
+
+```css
+.bar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 14px;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: calc(100vh - 88px);
+  overflow-y: auto;
+}
+```
+
+Also update the mobile media query — remove `.bar` `position: static; width: 100%;` since the panel handles it:
+
+```css
+@media (max-width: 768px) {
+  .vowels {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+```
+
+- [ ] **Step 4: Modify `FeedbackCard.module.css`**
+
+Remove the `position: static` from the mobile media query (panel handles stacking):
+
+```css
+@media (max-width: 768px) {
+  .card {
+    width: 100%;
+    margin-bottom: 14px;
+  }
+}
+```
+
+- [ ] **Step 5: Verify layout**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+Run: `npx vitest run src/__tests__/`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/AnalysisPage.tsx src/routes/AnalysisPage.module.css src/components/TargetPresetBar.module.css src/components/FeedbackCard.module.css
+git commit -m "feat(feedback): stack FeedbackCard below TargetPresetBar in left panel"
+```
+
+---
+
+### Task 11: 最终验证
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: all test files pass, 0 failures.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` produced.
+
+- [ ] **Step 4: Final commit check**
+
+Run: `git status --short` and `git log --oneline -8`
+Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
+++ b/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
@@ -602,7 +602,7 @@ Expected: all work committed, clean status.
 - Create: `src/feedback/status.ts`
 - Test: `src/__tests__/status.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `src/__tests__/status.test.ts`:
 
@@ -646,12 +646,12 @@ describe('getFormantStatus', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/status.test.ts`
 Expected: FAIL — `Cannot find module '../feedback/status'`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 Create `src/feedback/status.ts`:
 
@@ -669,12 +669,12 @@ export function getFormantStatus(
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run src/__tests__/status.test.ts`
 Expected: 8 tests PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/feedback/status.ts src/__tests__/status.test.ts
@@ -689,7 +689,7 @@ git commit -m "feat(feedback): add getFormantStatus shared evaluator"
 - Modify: `src/feedback/hitRate.ts`
 - Test: `src/__tests__/hitRate.test.ts`
 
-- [ ] **Step 1: Refactor implementation to use getFormantStatus**
+- [x] **Step 1: Refactor implementation to use getFormantStatus**
 
 Modify `src/feedback/hitRate.ts` — replace the inline boundary checks with the shared function:
 
@@ -728,17 +728,17 @@ export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
 }
 ```
 
-- [ ] **Step 2: Run existing hitRate tests to verify behavior unchanged**
+- [x] **Step 2: Run existing hitRate tests to verify behavior unchanged**
 
 Run: `npx vitest run src/__tests__/hitRate.test.ts`
 Expected: 7 tests PASS (no behavior change).
 
-- [ ] **Step 3: Typecheck**
+- [x] **Step 3: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/feedback/hitRate.ts
@@ -754,7 +754,7 @@ git commit -m "refactor(feedback): reuse getFormantStatus in evaluateHitRate"
 - Modify: `src/components/FeedbackCard.module.css`
 - Test: `src/__tests__/FeedbackCard.test.tsx`
 
-- [ ] **Step 1: Rewrite the failing test**
+- [x] **Step 1: Rewrite the failing test**
 
 Modify `src/__tests__/FeedbackCard.test.tsx`:
 
@@ -824,12 +824,12 @@ describe('FeedbackCard', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
 Expected: FAIL — current component returns null on no data, no value rows.
 
-- [ ] **Step 3: Rewrite minimal implementation**
+- [x] **Step 3: Rewrite minimal implementation**
 
 Modify `src/components/FeedbackCard.tsx`:
 
@@ -897,7 +897,7 @@ export function FeedbackCard() {
 }
 ```
 
-- [ ] **Step 4: Update CSS module**
+- [x] **Step 4: Update CSS module**
 
 Modify `src/components/FeedbackCard.module.css` — add value-row styles, keep existing summary styles. Note `.card` positioning will be changed in Task 10:
 
@@ -1003,17 +1003,17 @@ Modify `src/components/FeedbackCard.module.css` — add value-row styles, keep e
 }
 ```
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
 Expected: 6 tests PASS.
 
-- [ ] **Step 6: Typecheck**
+- [x] **Step 6: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/components/FeedbackCard.tsx src/components/FeedbackCard.module.css src/__tests__/FeedbackCard.test.tsx
@@ -1030,7 +1030,7 @@ git commit -m "feat(feedback): always-on card with real-time F0/F1/F2 values"
 - Modify: `src/components/TargetPresetBar.module.css`
 - Modify: `src/components/FeedbackCard.module.css`
 
-- [ ] **Step 1: Modify `AnalysisPage.tsx`**
+- [x] **Step 1: Modify `AnalysisPage.tsx`**
 
 Wrap `TargetPresetBar` and `FeedbackCard` in a side panel container. Change the current `<main>` block:
 
@@ -1047,7 +1047,7 @@ Wrap `TargetPresetBar` and `FeedbackCard` in a side panel container. Change the 
 </main>
 ```
 
-- [ ] **Step 2: Add `.sidePanel` to `AnalysisPage.module.css`**
+- [x] **Step 2: Add `.sidePanel` to `AnalysisPage.module.css`**
 
 Add:
 
@@ -1073,7 +1073,7 @@ Add:
 
 Merge the `.sidePanel` media query into the existing `@media (max-width: 768px)` block.
 
-- [ ] **Step 3: Modify `TargetPresetBar.module.css`**
+- [x] **Step 3: Modify `TargetPresetBar.module.css`**
 
 Remove absolute positioning from `.bar` (the side panel now positions it). `.bar` becomes:
 
@@ -1102,7 +1102,7 @@ Also update the mobile media query — remove `.bar` `position: static; width: 1
 }
 ```
 
-- [ ] **Step 4: Modify `FeedbackCard.module.css`**
+- [x] **Step 4: Modify `FeedbackCard.module.css`**
 
 Remove the `position: static` from the mobile media query (panel handles stacking):
 
@@ -1115,7 +1115,7 @@ Remove the `position: static` from the mobile media query (panel handles stackin
 }
 ```
 
-- [ ] **Step 5: Verify layout**
+- [x] **Step 5: Verify layout**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
@@ -1123,7 +1123,7 @@ Expected: no errors.
 Run: `npx vitest run src/__tests__/`
 Expected: all tests PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/routes/AnalysisPage.tsx src/routes/AnalysisPage.module.css src/components/TargetPresetBar.module.css src/components/FeedbackCard.module.css
@@ -1136,22 +1136,22 @@ git commit -m "feat(feedback): stack FeedbackCard below TargetPresetBar in left 
 
 **Files:** none
 
-- [ ] **Step 1: Typecheck**
+- [x] **Step 1: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 2: Full test suite**
+- [x] **Step 2: Full test suite**
 
 Run: `npm test`
 Expected: all test files pass, 0 failures.
 
-- [ ] **Step 3: Production build**
+- [x] **Step 3: Production build**
 
 Run: `npm run build`
 Expected: build succeeds, `dist/` produced.
 
-- [ ] **Step 4: Final commit check**
+- [x] **Step 4: Final commit check**
 
 Run: `git status --short` and `git log --oneline -8`
 Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
+++ b/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
@@ -1,0 +1,587 @@
+# 命中目标区间反馈系统 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a real-time feedback card that shows green "完美" when F0/F1/F2 all hit their target ranges, or orange deviation hints (e.g. "F0偏低") otherwise, via an extensible evaluator registry.
+
+**Architecture:** Each feedback type is a pure function `FeedbackEvaluator = (ctx) => FeedbackResult | null` registered in `src/feedback/index.ts`. A `useFeedback()` hook subscribes to `appStore` (latestFrame, bands) and runs all evaluators. `FeedbackCard` (in `src/components/`) is a pure renderer of `FeedbackResult[]`, placed in the right-side panel of `AnalysisPage` opposite `TargetPresetBar`.
+
+**Tech Stack:** TypeScript, React 18, Zustand (via `useAppStore`), Vitest + @testing-library/react (jsdom project), CSS Modules.
+
+---
+
+## File Structure
+
+- **Modify** `src/types/index.ts` — add `FeedbackStatus`, `FeedbackResult`, `FeedbackContext`, `FeedbackEvaluator`
+- **Create** `src/feedback/hitRate.ts` — `evaluateHitRate` pure function
+- **Create** `src/feedback/index.ts` — `FEEDBACK_EVALUATORS` registry + `useFeedback()` hook
+- **Create** `src/__tests__/hitRate.test.ts` — unit tests for `evaluateHitRate`
+- **Create** `src/__tests__/useFeedback.test.tsx` — hook tests against real store
+- **Create** `src/components/FeedbackCard.tsx` + `src/components/FeedbackCard.module.css`
+- **Create** `src/__tests__/FeedbackCard.test.tsx` — component render tests
+- **Modify** `src/routes/AnalysisPage.tsx` — render `<FeedbackCard />`
+- **Modify** `src/routes/AnalysisPage.module.css` — right-side panel layout + mobile stack
+
+**Important:** `evaluateHitRate` includes a `hasData` guard (all values null → return null) because the naive loop would otherwise report "完美" when every formant is null.
+
+---
+
+### Task 1: Add feedback types
+
+**Files:**
+- Modify: `src/types/index.ts`
+
+- [ ] **Step 1: Add types to `src/types/index.ts`**
+
+Append at the end of the file:
+
+```ts
+export type FeedbackStatus = 'hit' | 'miss' | 'idle'
+
+export interface FeedbackResult {
+  id: string
+  label: string
+  status: FeedbackStatus
+  message: string
+}
+
+export interface FeedbackContext {
+  latestFrame: AnalysisFrame | null
+  bands: TargetBands
+}
+
+export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/index.ts
+git commit -m "feat(feedback): add feedback types"
+```
+
+---
+
+### Task 2: evaluateHitRate evaluator (TDD)
+
+**Files:**
+- Create: `src/feedback/hitRate.ts`
+- Test: `src/__tests__/hitRate.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/hitRate.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { evaluateHitRate } from '../feedback/hitRate'
+import { VOWEL_PRESETS } from '../types'
+import type { FeedbackContext, AnalysisFrame } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function makeCtx(overrides: {
+  f0?: number | null
+  f1?: number | null
+  f2?: number | null
+}): FeedbackContext {
+  const frame: AnalysisFrame = {
+    time: 0.1,
+    f0: overrides.f0 ?? null,
+    f1: overrides.f1 ?? null,
+    f2: overrides.f2 ?? null,
+  }
+  return {
+    latestFrame: frame,
+    bands: {
+      f0: { range: vowelA.f0, color: '#10B981' },
+      f1: { range: vowelA.f1, color: '#3B82F6' },
+      f2: { range: vowelA.f2, color: '#F59E0B' },
+    },
+  }
+}
+
+describe('evaluateHitRate', () => {
+  it('returns null when no latest frame', () => {
+    const ctx = makeCtx({})
+    ctx.latestFrame = null
+    expect(evaluateHitRate(ctx)).toBeNull()
+  })
+
+  it('returns null when all formants are null', () => {
+    expect(evaluateHitRate(makeCtx({}))).toBeNull()
+  })
+
+  it('returns hit with "完美" when all in range', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    const result = evaluateHitRate(makeCtx({
+      f0: mid(vowelA.f0[0], vowelA.f0[1]),
+      f1: mid(vowelA.f1[0], vowelA.f1[1]),
+      f2: mid(vowelA.f2[0], vowelA.f2[1]),
+    }))
+    expect(result).toEqual({
+      id: 'hit-rate',
+      label: '目标区间',
+      status: 'hit',
+      message: '完美',
+    })
+  })
+
+  it('reports F0偏低 when below lower bound', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: vowelA.f0[0] - 50,
+      f1: (vowelA.f1[0] + vowelA.f1[1]) / 2,
+      f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toContain('F0偏低')
+  })
+
+  it('reports F2偏高 when above upper bound', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      f1: (vowelA.f1[0] + vowelA.f1[1]) / 2,
+      f2: vowelA.f2[1] + 100,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toContain('F2偏高')
+  })
+
+  it('merges multiple hints with space separator', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: vowelA.f0[0] - 50,
+      f1: vowelA.f1[1] + 200,
+      f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toBe('F0偏低 F1偏高')
+  })
+
+  it('ignores null formants without false negatives', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      f1: null,
+      f2: null,
+    }))
+    expect(result).toEqual({
+      id: 'hit-rate',
+      label: '目标区间',
+      status: 'hit',
+      message: '完美',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/hitRate.test.ts`
+Expected: FAIL — `Cannot find module '../feedback/hitRate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/feedback/hitRate.ts`:
+
+```ts
+import type { FeedbackContext, FeedbackResult } from '../types'
+
+const KEYS = ['f0', 'f1', 'f2'] as const
+
+export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
+  const { latestFrame, bands } = ctx
+  if (!latestFrame) return null
+
+  const hints: string[] = []
+  let hasData = false
+  let allHit = true
+
+  for (const k of KEYS) {
+    const v = latestFrame[k]
+    const range = bands[k].range
+    if (v == null || !Number.isFinite(v)) continue
+    hasData = true
+    if (v < range[0]) {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏低`)
+    } else if (v > range[1]) {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏高`)
+    }
+  }
+
+  if (!hasData) return null
+  if (allHit) {
+    return { id: 'hit-rate', label: '目标区间', status: 'hit', message: '完美' }
+  }
+  return { id: 'hit-rate', label: '目标区间', status: 'miss', message: hints.join(' ') }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/hitRate.test.ts`
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feedback/hitRate.ts src/__tests__/hitRate.test.ts
+git commit -m "feat(feedback): add evaluateHitRate evaluator"
+```
+
+---
+
+### Task 3: useFeedback hook (TDD)
+
+**Files:**
+- Create: `src/feedback/index.ts`
+- Test: `src/__tests__/useFeedback.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/useFeedback.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFeedback } from '../feedback'
+import { useAppStore } from '../store/appStore'
+import { VOWEL_PRESETS } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function setFrame(f0: number | null, f1: number | null, f2: number | null) {
+  useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
+}
+
+describe('useFeedback', () => {
+  beforeEach(() => {
+    useAppStore.getState().reset()
+  })
+
+  it('returns empty array with no data', () => {
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toEqual([])
+  })
+
+  it('returns hit result when all in range', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].id).toBe('hit-rate')
+    expect(result.current[0].status).toBe('hit')
+    expect(result.current[0].message).toBe('完美')
+  })
+
+  it('reacts to latestFrame updates', () => {
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toEqual([])
+
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    act(() => {
+      setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    })
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].status).toBe('miss')
+    expect(result.current[0].message).toBe('F2偏高')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/useFeedback.test.tsx`
+Expected: FAIL — `Cannot find module '../feedback'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/feedback/index.ts`:
+
+```ts
+import { useAppStore } from '../store/appStore'
+import type { FeedbackEvaluator, FeedbackResult } from '../types'
+import { evaluateHitRate } from './hitRate'
+
+export const FEEDBACK_EVALUATORS: FeedbackEvaluator[] = [
+  evaluateHitRate,
+]
+
+export function useFeedback(): FeedbackResult[] {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
+  return FEEDBACK_EVALUATORS
+    .map(fn => fn({ latestFrame, bands }))
+    .filter((r): r is FeedbackResult => r !== null)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/useFeedback.test.tsx`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feedback/index.ts src/__tests__/useFeedback.test.tsx
+git commit -m "feat(feedback): add useFeedback hook with evaluator registry"
+```
+
+---
+
+### Task 4: FeedbackCard component (TDD)
+
+**Files:**
+- Create: `src/components/FeedbackCard.tsx`
+- Create: `src/components/FeedbackCard.module.css`
+- Test: `src/__tests__/FeedbackCard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/FeedbackCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeedbackCard } from '../components/FeedbackCard'
+import { useAppStore } from '../store/appStore'
+import { VOWEL_PRESETS } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function setFrame(f0: number | null, f1: number | null, f2: number | null) {
+  useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
+}
+
+describe('FeedbackCard', () => {
+  beforeEach(() => {
+    useAppStore.getState().reset()
+  })
+
+  it('renders nothing when no data', () => {
+    const { container } = render(<FeedbackCard />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders hit result with 完美', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText('目标区间')).toBeTruthy()
+    expect(screen.getByText('完美')).toBeTruthy()
+  })
+
+  it('renders miss result with deviation hints', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    render(<FeedbackCard />)
+    expect(screen.getByText('F2偏高')).toBeTruthy()
+  })
+
+  it('shows card header 实时反馈 when results exist', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText('实时反馈')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: FAIL — `Cannot find module '../components/FeedbackCard'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/components/FeedbackCard.tsx`:
+
+```tsx
+import { useFeedback } from '../feedback'
+import styles from './FeedbackCard.module.css'
+
+export function FeedbackCard() {
+  const results = useFeedback()
+  if (results.length === 0) return null
+  return (
+    <aside className={styles.card} aria-label="实时反馈">
+      <div className={styles.header}>实时反馈</div>
+      <ul className={styles.list}>
+        {results.map(result => (
+          <li
+            key={result.id}
+            className={styles.row}
+            data-status={result.status}
+          >
+            <span className={styles.label}>{result.label}</span>
+            <span
+              className={`${styles.value} ${result.status === 'hit' ? styles.valueHit : ''}`}
+            >
+              {result.message}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}
+```
+
+Create `src/components/FeedbackCard.module.css`:
+
+```css
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  box-shadow: var(--shadow-card);
+  position: absolute;
+  top: 16px;
+  left: calc(50% + 466px);
+  width: 220px;
+}
+.header {
+  font-size: 12px;
+  color: var(--text-soft);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+.list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px dashed var(--border);
+  padding-top: 12px;
+}
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.row[data-status="idle"] {
+  opacity: 0.55;
+}
+.label {
+  font-size: 11px;
+  color: var(--text-soft);
+}
+.value {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-mute);
+}
+.valueHit {
+  color: var(--hit);
+  border-radius: 4px;
+  animation: pulseGlow 1.6s ease-out infinite;
+}
+.row[data-status="miss"] .value {
+  color: var(--warn);
+}
+
+@keyframes pulseGlow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(16, 185, 129, 0);
+  }
+}
+
+@media (max-width: 768px) {
+  .card {
+    position: static;
+    width: 100%;
+    margin-bottom: 14px;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/FeedbackCard.tsx src/components/FeedbackCard.module.css src/__tests__/FeedbackCard.test.tsx
+git commit -m "feat(feedback): add FeedbackCard component"
+```
+
+---
+
+### Task 5: Wire into AnalysisPage
+
+**Files:**
+- Modify: `src/routes/AnalysisPage.tsx`
+- Modify: `src/routes/AnalysisPage.module.css`
+
+- [ ] **Step 1: Modify `AnalysisPage.tsx`**
+
+Add import at top (after existing component imports):
+
+```tsx
+import { FeedbackCard } from '../components/FeedbackCard'
+```
+
+Inside `<main className={styles.content}>`, after `<TargetPresetBar />`, add:
+
+```tsx
+<FeedbackCard />
+```
+
+Note: `FeedbackCard` subscribes to the store internally via `useFeedback()` — AnalysisPage does NOT call `useFeedback()` itself, so the page doesn't re-render on every frame.
+
+- [ ] **Step 2: Verify AnalysisPage layout**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Run full unit test suite**
+
+Run: `npx vitest run src/__tests__/`
+Expected: all tests PASS (existing + new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/AnalysisPage.tsx
+git commit -m "feat(feedback): wire FeedbackCard into AnalysisPage"
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: 19 test files pass, 115 + 15 = 130 tests, 0 failures.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` produced.
+
+- [ ] **Step 4: Final commit check**
+
+Run: `git status --short` and `git log --oneline -8`
+Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
+++ b/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
@@ -1155,3 +1155,469 @@ Expected: build succeeds, `dist/` produced.
 
 Run: `git status --short` and `git log --oneline -8`
 Expected: all work committed, clean status.
+
+---
+
+# 修订计划（2026-08-01）：图例可见性 store 驱动，实时反馈联动
+
+> 用户需求变更：在 FormantChart 图例隐藏某 series（f0/f1/f2）时，实时反馈卡片也不显示该项目——数值行整行不渲染，汇总判定忽略隐藏维度（如隐藏 f1/f2 后仅 f0 命中即显示"完美"）。图例可见性从 AnalysisPage 局部 `useState` 提升到 Zustand store（`formantVisible`），遵循"命令驱动控制、数据经 store 流向组件"原则。更新后的 spec：`docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md`。
+
+**修订目标：** 新增 `formantVisible` 至 appStore（与 bands 同级），图例按钮写 store，FormantChart / FeedbackCard / useFeedback 全部订阅 store；`FeedbackContext.visible` 必填；evaluateHitRate 跳过隐藏维度；FeedbackCard 数值行按可见性过滤。
+
+---
+
+### Task 12: 类型 + store 图例可见性（TDD）
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/store/appStore.ts`
+- Test: `src/__tests__/appStore.test.ts`
+
+- [ ] **Step 1: 追加测试到 `appStore.test.ts`**
+
+在 `describe('reset')` 后追加：
+
+```ts
+describe('formantVisible', () => {
+  it('defaults to all visible', () => {
+    const { formantVisible } = useAppStore.getState()
+    expect(formantVisible).toEqual({ f0: true, f1: true, f2: true })
+  })
+
+  it('toggleFormantVisible flips a single key', () => {
+    useAppStore.getState().toggleFormantVisible('f1')
+    const { formantVisible } = useAppStore.getState()
+    expect(formantVisible.f0).toBe(true)
+    expect(formantVisible.f1).toBe(false)
+    expect(formantVisible.f2).toBe(true)
+  })
+
+  it('toggleFormantVisible flips back', () => {
+    useAppStore.getState().toggleFormantVisible('f0')
+    useAppStore.getState().toggleFormantVisible('f0')
+    expect(useAppStore.getState().formantVisible.f0).toBe(true)
+  })
+})
+
+describe('clearFrames preserves formantVisible', () => {
+  it('keeps hidden state across clear', () => {
+    useAppStore.getState().toggleFormantVisible('f1')
+    useAppStore.getState().appendFrame(makeFrame({ time: 0.01, f0: 220 }))
+    useAppStore.getState().clearFrames()
+    expect(useAppStore.getState().formantVisible.f1).toBe(false)
+    expect(useAppStore.getState().frames).toEqual([])
+  })
+})
+
+describe('reset restores formantVisible', () => {
+  it('restores all visible', () => {
+    useAppStore.getState().toggleFormantVisible('f2')
+    useAppStore.getState().reset()
+    expect(useAppStore.getState().formantVisible).toEqual({ f0: true, f1: true, f2: true })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/appStore.test.ts`
+Expected: FAIL — `formantVisible` / `toggleFormantVisible` 不存在。
+
+- [ ] **Step 3: 更新 `src/types/index.ts`**
+
+追加到文件末尾：
+
+```ts
+export type FormantSeries = 'f0' | 'f1' | 'f2'
+export type FormantVisibility = Record<FormantSeries, boolean>
+
+export interface FeedbackContext {
+  latestFrame: AnalysisFrame | null
+  bands: TargetBands
+  visible: FormantVisibility
+}
+```
+
+（替换现有 `FeedbackContext`，删除旧的 `latestFrame`/`bands` 定义，补 `visible`。）
+
+- [ ] **Step 4: 更新 `src/store/appStore.ts`**
+
+- import 增加 `FormantSeries, FormantVisibility`
+- `AppState` 增加 `formantVisible: FormantVisibility`
+- `AppActions` 增加 `toggleFormantVisible: (key: FormantSeries) => void`
+- `initialState` 增加 `formantVisible: { f0: true, f1: true, f2: true }`
+- store 实现增加：
+
+```ts
+toggleFormantVisible: (key) => set((state) => ({
+  formantVisible: { ...state.formantVisible, [key]: !state.formantVisible[key] },
+})),
+```
+
+`clearFrames()` 不触碰 `formantVisible`（自然保留）；`reset()` 恢复 initialState（自然恢复）。
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/appStore.test.ts`
+Expected: 新增 5 个测试 PASS。
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误。注意：`FeedbackContext` 增加必填 `visible` 后，`hitRate.ts` / `index.ts` 若未传会报错，此处在下一步一并修复。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/index.ts src/store/appStore.ts src/__tests__/appStore.test.ts
+git commit -m "feat(feedback): add formantVisible to store with toggle action"
+```
+
+---
+
+### Task 13: evaluateHitRate + useFeedback 接入 visible（TDD）
+
+**Files:**
+- Modify: `src/feedback/hitRate.ts`
+- Modify: `src/feedback/index.ts`
+- Test: `src/__tests__/hitRate.test.ts`
+- Test: `src/__tests__/useFeedback.test.tsx`
+
+- [ ] **Step 1: 更新 `hitRate.test.ts`**
+
+`makeCtx` 增加 `visible` 参数，并追加图例联动用例：
+
+```ts
+function makeCtx(overrides: {
+  f0?: number | null
+  f1?: number | null
+  f2?: number | null
+  visible?: Partial<Record<'f0' | 'f1' | 'f2', boolean>>
+}): FeedbackContext {
+  const frame: AnalysisFrame = {
+    time: 0.1,
+    f0: overrides.f0 ?? null,
+    f1: overrides.f1 ?? null,
+    f2: overrides.f2 ?? null,
+  }
+  return {
+    latestFrame: frame,
+    bands: {
+      f0: { range: vowelA.f0, color: '#10B981' },
+      f1: { range: vowelA.f1, color: '#3B82F6' },
+      f2: { range: vowelA.f2, color: '#F59E0B' },
+    },
+    visible: { f0: true, f1: true, f2: true, ...overrides.visible },
+  }
+}
+```
+
+追加用例：
+
+```ts
+it('ignores hidden out-of-range dims (returns hit)', () => {
+  const result = evaluateHitRate(makeCtx({
+    f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+    f1: vowelA.f1[1] + 200,
+    f2: vowelA.f2[1] + 200,
+    visible: { f1: false, f2: false },
+  }))
+  expect(result).toEqual({
+    id: 'hit-rate',
+    label: '目标区间',
+    status: 'hit',
+    message: '完美',
+  })
+})
+
+it('hides deviation hints for hidden dims', () => {
+  const result = evaluateHitRate(makeCtx({
+    f0: vowelA.f0[0] - 50,
+    f1: vowelA.f1[1] + 200,
+    f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+    visible: { f1: false },
+  }))
+  expect(result?.status).toBe('miss')
+  expect(result?.message).toBe('F0偏低')
+})
+
+it('returns null when all dims hidden', () => {
+  const result = evaluateHitRate(makeCtx({
+    f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+    visible: { f0: false, f1: false, f2: false },
+  }))
+  expect(result).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/hitRate.test.ts`
+Expected: FAIL — 用例红（实现未跳过隐藏维度）。
+
+- [ ] **Step 3: 更新 `src/feedback/hitRate.ts`**
+
+`evaluateHitRate` 循环开头增加可见性跳过：
+
+```ts
+for (const k of KEYS) {
+  if (!visible[k]) continue
+  const status = getFormantStatus(latestFrame[k], bands[k].range)
+  ...
+}
+```
+
+- [ ] **Step 4: Run hitRate test to verify it passes**
+
+Run: `npx vitest run src/__tests__/hitRate.test.ts`
+Expected: 10 个测试 PASS（7 旧 + 3 新）。
+
+- [ ] **Step 5: 更新 `useFeedback.test.tsx` 追加用例**
+
+```ts
+it('respects store formantVisible (hidden out-of-range is ignored)', () => {
+  useAppStore.getState().toggleFormantVisible('f2')
+  const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+  act(() => {
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+  })
+  const { result } = renderHook(() => useFeedback())
+  expect(result.current).toHaveLength(1)
+  expect(result.current[0].status).toBe('hit')
+  expect(result.current[0].message).toBe('完美')
+})
+```
+
+- [ ] **Step 6: 更新 `src/feedback/index.ts`**
+
+`useFeedback` 订阅 `formantVisible` 并传入 ctx：
+
+```ts
+export function useFeedback(): FeedbackResult[] {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
+  const visible = useAppStore(s => s.formantVisible)
+  return FEEDBACK_EVALUATORS
+    .map(fn => fn({ latestFrame, bands, visible }))
+    .filter((r): r is FeedbackResult => r !== null)
+}
+```
+
+- [ ] **Step 7: Run useFeedback test to verify it passes**
+
+Run: `npx vitest run src/__tests__/useFeedback.test.tsx`
+Expected: 4 个测试 PASS。
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/feedback/hitRate.ts src/feedback/index.ts src/__tests__/hitRate.test.ts src/__tests__/useFeedback.test.tsx
+git commit -m "feat(feedback): respect formantVisible in evaluator and hook"
+```
+
+---
+
+### Task 14: FeedbackCard 数值行按可见性过滤（TDD）
+
+**Files:**
+- Modify: `src/components/FeedbackCard.tsx`
+- Test: `src/__tests__/FeedbackCard.test.tsx`
+
+- [ ] **Step 1: 追加测试到 `FeedbackCard.test.tsx`**
+
+```ts
+it('hides value row for hidden series', () => {
+  useAppStore.getState().toggleFormantVisible('f1')
+  setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+  render(<FeedbackCard />)
+  expect(screen.queryByText('F1')).toBeNull()
+  expect(screen.queryByText(`${mid(vowelA.f1[0], vowelA.f1[1])} Hz`)).toBeNull()
+  expect(screen.getByText('F0')).toBeTruthy()
+  expect(screen.getByText('F2')).toBeTruthy()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: FAIL — F1 行仍渲染。
+
+- [ ] **Step 3: 更新 `src/components/FeedbackCard.tsx`**
+
+- 订阅 `formantVisible`：`const formantVisible = useAppStore(s => s.formantVisible)`
+- 数值行遍历改为过滤：
+
+```tsx
+{KEYS.filter(key => formantVisible[key]).map(key => {
+  ...
+})}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
+Expected: 8 个测试 PASS（7 旧 + 1 新）。
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FeedbackCard.tsx src/__tests__/FeedbackCard.test.tsx
+git commit -m "feat(feedback): filter FeedbackCard value rows by formantVisible"
+```
+
+---
+
+### Task 15: FormantChart 读 store + AnalysisPage 图例写 store（TDD）
+
+**Files:**
+- Modify: `src/components/FormantChart.tsx`
+- Modify: `src/routes/AnalysisPage.tsx`
+- Test: `src/__tests__/FormantChart.test.tsx`
+- Test: `src/__tests__/AnalysisPage.test.tsx`
+
+- [ ] **Step 1: 更新 `FormantChart.test.tsx`**
+
+删除 `seriesVisible` prop 用法，改为 store 驱动。将两个用例改为：
+
+```tsx
+it('renders data for all series by default', () => {
+  useAppStore.getState().setFrames(FRAMES)
+  render(<FormantChart />)
+  expect(seriesByName('F1').data).toHaveLength(2)
+  expect(seriesByName('F1').markLine).toBeDefined()
+})
+
+it('empties data and removes markLine for hidden series', () => {
+  useAppStore.getState().setFrames(FRAMES)
+  useAppStore.getState().toggleFormantVisible('f1')
+  render(<FormantChart />)
+  expect(seriesByName('F1').data).toEqual([])
+  expect(seriesByName('F1').markLine).toBeUndefined()
+  expect(seriesByName('F0').data).toHaveLength(2)
+  expect(seriesByName('F2').data).toHaveLength(2)
+})
+
+it('re-renders when store formantVisible changes', () => {
+  useAppStore.getState().setFrames(FRAMES)
+  render(<FormantChart />)
+  expect(seriesByName('F0').data).toHaveLength(2)
+
+  useAppStore.getState().toggleFormantVisible('f0')
+
+  expect(seriesByName('F0').data).toEqual([])
+  expect(seriesByName('F0').markLine).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/FormantChart.test.tsx`
+Expected: FAIL — 当前 `seriesVisible` prop 逻辑仍在；改 store 后不重渲染。
+
+- [ ] **Step 3: 更新 `src/components/FormantChart.tsx`**
+
+- 移除 `seriesVisible` prop；`FormantChartProps` 仅保留 `cursorTime` / `onFrameClick`
+- 组件内订阅：`const formantVisible = useAppStore(s => s.formantVisible)`
+- `seriesVisibleRef` 初始化改为默认全 true（现已是），同步 effect 改为：
+
+```tsx
+useEffect(() => {
+  seriesVisibleRef.current = formantVisible
+  renderChart(frames, cursorTime, bands, isLiveRef.current, false)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [formantVisible])
+```
+
+（`renderChart` 内部继续用 `seriesVisibleRef.current`，无需改动。）
+
+- [ ] **Step 4: Run FormantChart test to verify it passes**
+
+Run: `npx vitest run src/__tests__/FormantChart.test.tsx`
+Expected: 3 个测试 PASS。
+
+- [ ] **Step 5: 更新 `AnalysisPage.test.tsx`**
+
+用例保持（图例点击改走 store 后行为一致），确认 `data-active` 仍反映 store 状态。若无需改动则跳过；运行确认通过：
+
+Run: `npx vitest run src/__tests__/AnalysisPage.test.tsx`
+Expected: PASS。
+
+- [ ] **Step 6: 更新 `src/routes/AnalysisPage.tsx`**
+
+- 移除 `seriesVisible` 局部 state 与 `handleToggleSeries`
+- import `useAppStore`，订阅 `formantVisible` 与 `toggleFormantVisible`：
+
+```tsx
+const formantVisible = useAppStore(s => s.formantVisible)
+const toggleFormantVisible = useAppStore(s => s.toggleFormantVisible)
+```
+
+- `LegendKey` 改用共享类型 `FormantSeries`（import 自 types），`LEGEND_KEYS` 保留
+- 图例按钮改为：
+
+```tsx
+<button
+  key={key}
+  className={styles.legendItem}
+  data-key={key}
+  data-active={String(formantVisible[key])}
+  onClick={() => toggleFormantVisible(key)}
+>
+  <i style={{ background: COLORS[key] }}></i>{key.toUpperCase()}
+</button>
+```
+
+- `<FormantChart>` 调用去掉 `seriesVisible` prop：`<FormantChart cursorTime={cursorTime} />`
+
+- [ ] **Step 7: Run AnalysisPage test to verify it passes**
+
+Run: `npx vitest run src/__tests__/AnalysisPage.test.tsx`
+Expected: PASS（图例点击切换数据可见性）。
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/FormantChart.tsx src/routes/AnalysisPage.tsx src/__tests__/FormantChart.test.tsx src/__tests__/AnalysisPage.test.tsx
+git commit -m "feat(feedback): drive chart legend from store formantVisible"
+```
+
+---
+
+### Task 16: 最终验证
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: all test files pass, 0 failures.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` produced.
+
+- [ ] **Step 4: Final commit check**
+
+Run: `git status --short` and `git log --oneline -8`
+Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
+++ b/docs/superpowers/plans/2026-08-01-hit-target-feedback.md
@@ -1173,7 +1173,7 @@ Expected: all work committed, clean status.
 - Modify: `src/store/appStore.ts`
 - Test: `src/__tests__/appStore.test.ts`
 
-- [ ] **Step 1: 追加测试到 `appStore.test.ts`**
+- [x] **Step 1: 追加测试到 `appStore.test.ts`**
 
 在 `describe('reset')` 后追加：
 
@@ -1218,12 +1218,12 @@ describe('reset restores formantVisible', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/appStore.test.ts`
 Expected: FAIL — `formantVisible` / `toggleFormantVisible` 不存在。
 
-- [ ] **Step 3: 更新 `src/types/index.ts`**
+- [x] **Step 3: 更新 `src/types/index.ts`**
 
 追加到文件末尾：
 
@@ -1240,7 +1240,7 @@ export interface FeedbackContext {
 
 （替换现有 `FeedbackContext`，删除旧的 `latestFrame`/`bands` 定义，补 `visible`。）
 
-- [ ] **Step 4: 更新 `src/store/appStore.ts`**
+- [x] **Step 4: 更新 `src/store/appStore.ts`**
 
 - import 增加 `FormantSeries, FormantVisibility`
 - `AppState` 增加 `formantVisible: FormantVisibility`
@@ -1256,17 +1256,17 @@ toggleFormantVisible: (key) => set((state) => ({
 
 `clearFrames()` 不触碰 `formantVisible`（自然保留）；`reset()` 恢复 initialState（自然恢复）。
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 Run: `npx vitest run src/__tests__/appStore.test.ts`
 Expected: 新增 5 个测试 PASS。
 
-- [ ] **Step 6: Typecheck**
+- [x] **Step 6: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: 无错误。注意：`FeedbackContext` 增加必填 `visible` 后，`hitRate.ts` / `index.ts` 若未传会报错，此处在下一步一并修复。
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/types/index.ts src/store/appStore.ts src/__tests__/appStore.test.ts
@@ -1283,7 +1283,7 @@ git commit -m "feat(feedback): add formantVisible to store with toggle action"
 - Test: `src/__tests__/hitRate.test.ts`
 - Test: `src/__tests__/useFeedback.test.tsx`
 
-- [ ] **Step 1: 更新 `hitRate.test.ts`**
+- [x] **Step 1: 更新 `hitRate.test.ts`**
 
 `makeCtx` 增加 `visible` 参数，并追加图例联动用例：
 
@@ -1350,12 +1350,12 @@ it('returns null when all dims hidden', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/hitRate.test.ts`
 Expected: FAIL — 用例红（实现未跳过隐藏维度）。
 
-- [ ] **Step 3: 更新 `src/feedback/hitRate.ts`**
+- [x] **Step 3: 更新 `src/feedback/hitRate.ts`**
 
 `evaluateHitRate` 循环开头增加可见性跳过：
 
@@ -1367,12 +1367,12 @@ for (const k of KEYS) {
 }
 ```
 
-- [ ] **Step 4: Run hitRate test to verify it passes**
+- [x] **Step 4: Run hitRate test to verify it passes**
 
 Run: `npx vitest run src/__tests__/hitRate.test.ts`
 Expected: 10 个测试 PASS（7 旧 + 3 新）。
 
-- [ ] **Step 5: 更新 `useFeedback.test.tsx` 追加用例**
+- [x] **Step 5: 更新 `useFeedback.test.tsx` 追加用例**
 
 ```ts
 it('respects store formantVisible (hidden out-of-range is ignored)', () => {
@@ -1388,7 +1388,7 @@ it('respects store formantVisible (hidden out-of-range is ignored)', () => {
 })
 ```
 
-- [ ] **Step 6: 更新 `src/feedback/index.ts`**
+- [x] **Step 6: 更新 `src/feedback/index.ts`**
 
 `useFeedback` 订阅 `formantVisible` 并传入 ctx：
 
@@ -1403,17 +1403,17 @@ export function useFeedback(): FeedbackResult[] {
 }
 ```
 
-- [ ] **Step 7: Run useFeedback test to verify it passes**
+- [x] **Step 7: Run useFeedback test to verify it passes**
 
 Run: `npx vitest run src/__tests__/useFeedback.test.tsx`
 Expected: 4 个测试 PASS。
 
-- [ ] **Step 8: Typecheck**
+- [x] **Step 8: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: 无错误。
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add src/feedback/hitRate.ts src/feedback/index.ts src/__tests__/hitRate.test.ts src/__tests__/useFeedback.test.tsx
@@ -1428,7 +1428,7 @@ git commit -m "feat(feedback): respect formantVisible in evaluator and hook"
 - Modify: `src/components/FeedbackCard.tsx`
 - Test: `src/__tests__/FeedbackCard.test.tsx`
 
-- [ ] **Step 1: 追加测试到 `FeedbackCard.test.tsx`**
+- [x] **Step 1: 追加测试到 `FeedbackCard.test.tsx`**
 
 ```ts
 it('hides value row for hidden series', () => {
@@ -1442,12 +1442,12 @@ it('hides value row for hidden series', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
 Expected: FAIL — F1 行仍渲染。
 
-- [ ] **Step 3: 更新 `src/components/FeedbackCard.tsx`**
+- [x] **Step 3: 更新 `src/components/FeedbackCard.tsx`**
 
 - 订阅 `formantVisible`：`const formantVisible = useAppStore(s => s.formantVisible)`
 - 数值行遍历改为过滤：
@@ -1458,17 +1458,17 @@ Expected: FAIL — F1 行仍渲染。
 })}
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run src/__tests__/FeedbackCard.test.tsx`
 Expected: 8 个测试 PASS（7 旧 + 1 新）。
 
-- [ ] **Step 5: Typecheck**
+- [x] **Step 5: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: 无错误。
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/components/FeedbackCard.tsx src/__tests__/FeedbackCard.test.tsx
@@ -1485,7 +1485,7 @@ git commit -m "feat(feedback): filter FeedbackCard value rows by formantVisible"
 - Test: `src/__tests__/FormantChart.test.tsx`
 - Test: `src/__tests__/AnalysisPage.test.tsx`
 
-- [ ] **Step 1: 更新 `FormantChart.test.tsx`**
+- [x] **Step 1: 更新 `FormantChart.test.tsx`**
 
 删除 `seriesVisible` prop 用法，改为 store 驱动。将两个用例改为：
 
@@ -1519,12 +1519,12 @@ it('re-renders when store formantVisible changes', () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run src/__tests__/FormantChart.test.tsx`
 Expected: FAIL — 当前 `seriesVisible` prop 逻辑仍在；改 store 后不重渲染。
 
-- [ ] **Step 3: 更新 `src/components/FormantChart.tsx`**
+- [x] **Step 3: 更新 `src/components/FormantChart.tsx`**
 
 - 移除 `seriesVisible` prop；`FormantChartProps` 仅保留 `cursorTime` / `onFrameClick`
 - 组件内订阅：`const formantVisible = useAppStore(s => s.formantVisible)`
@@ -1540,19 +1540,19 @@ useEffect(() => {
 
 （`renderChart` 内部继续用 `seriesVisibleRef.current`，无需改动。）
 
-- [ ] **Step 4: Run FormantChart test to verify it passes**
+- [x] **Step 4: Run FormantChart test to verify it passes**
 
 Run: `npx vitest run src/__tests__/FormantChart.test.tsx`
 Expected: 3 个测试 PASS。
 
-- [ ] **Step 5: 更新 `AnalysisPage.test.tsx`**
+- [x] **Step 5: 更新 `AnalysisPage.test.tsx`**
 
 用例保持（图例点击改走 store 后行为一致），确认 `data-active` 仍反映 store 状态。若无需改动则跳过；运行确认通过：
 
 Run: `npx vitest run src/__tests__/AnalysisPage.test.tsx`
 Expected: PASS。
 
-- [ ] **Step 6: 更新 `src/routes/AnalysisPage.tsx`**
+- [x] **Step 6: 更新 `src/routes/AnalysisPage.tsx`**
 
 - 移除 `seriesVisible` 局部 state 与 `handleToggleSeries`
 - import `useAppStore`，订阅 `formantVisible` 与 `toggleFormantVisible`：
@@ -1579,17 +1579,17 @@ const toggleFormantVisible = useAppStore(s => s.toggleFormantVisible)
 
 - `<FormantChart>` 调用去掉 `seriesVisible` prop：`<FormantChart cursorTime={cursorTime} />`
 
-- [ ] **Step 7: Run AnalysisPage test to verify it passes**
+- [x] **Step 7: Run AnalysisPage test to verify it passes**
 
 Run: `npx vitest run src/__tests__/AnalysisPage.test.tsx`
 Expected: PASS（图例点击切换数据可见性）。
 
-- [ ] **Step 8: Typecheck**
+- [x] **Step 8: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: 无错误。
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add src/components/FormantChart.tsx src/routes/AnalysisPage.tsx src/__tests__/FormantChart.test.tsx src/__tests__/AnalysisPage.test.tsx
@@ -1602,22 +1602,22 @@ git commit -m "feat(feedback): drive chart legend from store formantVisible"
 
 **Files:** none
 
-- [ ] **Step 1: Typecheck**
+- [x] **Step 1: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 2: Full test suite**
+- [x] **Step 2: Full test suite**
 
 Run: `npm test`
 Expected: all test files pass, 0 failures.
 
-- [ ] **Step 3: Production build**
+- [x] **Step 3: Production build**
 
 Run: `npm run build`
 Expected: build succeeds, `dist/` produced.
 
-- [ ] **Step 4: Final commit check**
+- [x] **Step 4: Final commit check**
 
 Run: `git status --short` and `git log --oneline -8`
 Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-mobile-single-screen-layout.md
+++ b/docs/superpowers/plans/2026-08-01-mobile-single-screen-layout.md
@@ -1,6 +1,6 @@
 # 移动端一屏适配 Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** On mobile (`max-width: 768px`) constrain all UI within one viewport height (no page scroll): Toolbar fixed, TargetPresetBar + FeedbackCard side-by-side in one row, two charts flex-fill remaining height.
 
@@ -28,7 +28,7 @@
 - Modify: `src/routes/AnalysisPage.tsx:47`
 - Modify: `src/routes/AnalysisPage.module.css:108-118`
 
-- [ ] **Step 1: Add `.page` class to AnalysisPage root**
+- [x] **Step 1: Add `.page` class to AnalysisPage root**
 
 In `src/routes/AnalysisPage.tsx`, change the root wrapper from a bare `<div>` to `<div className={styles.page}>`:
 
@@ -40,7 +40,7 @@ In `src/routes/AnalysisPage.tsx`, change the root wrapper from a bare `<div>` to
 
 `styles` is already imported (`import styles from './AnalysisPage.module.css'`).
 
-- [ ] **Step 2: Add `.page` base rule and rework the mobile media query**
+- [x] **Step 2: Add `.page` base rule and rework the mobile media query**
 
 In `src/routes/AnalysisPage.module.css`, add a `.page` base rule right after `.content` (desktop: plain block, no effect). Current lines 1-6:
 
@@ -120,7 +120,7 @@ Notes:
 - `.chartWrapper` keeps its base `width: calc(100% - 20px)`; only height/flex change.
 - `.card` and `.chartsColumnCard` base rules already provide `flex: 1; min-height: 0` for the chart cards; `.chartArea` already has `flex: 1 1 auto; min-height: 120px`.
 
-- [ ] **Step 3: Run unit tests + typecheck**
+- [x] **Step 3: Run unit tests + typecheck**
 
 Run: `npx vitest run src/__tests__/`
 Expected: all existing tests pass (jsdom ignores CSS media queries; no test should change).
@@ -128,7 +128,7 @@ Expected: all existing tests pass (jsdom ignores CSS media queries; no test shou
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/routes/AnalysisPage.tsx src/routes/AnalysisPage.module.css
@@ -142,7 +142,7 @@ git commit -m "feat(mobile): single-screen flex column layout for mobile"
 **Files:**
 - Modify: `src/components/TargetPresetBar.module.css:114-118`
 
-- [ ] **Step 1: Add mobile `.bar` flex + compaction rules**
+- [x] **Step 1: Add mobile `.bar` flex + compaction rules**
 
 The current mobile media query (lines 114-118):
 
@@ -181,7 +181,7 @@ Notes:
 - `min-width: 0` allows the bar to shrink below its content width inside the flex row.
 - Band input compaction reduces `.bandLo`/`.bandHi` height from 22px to 20px. Their base rule (lines 83-97) also contains `flex: 1; min-width: 0` which is preserved.
 
-- [ ] **Step 2: Run TargetPresetBar tests + typecheck**
+- [x] **Step 2: Run TargetPresetBar tests + typecheck**
 
 Run: `npx vitest run src/__tests__/TargetPresetBar.test.tsx src/__tests__/FeedbackCard.test.tsx`
 Expected: all pass.
@@ -189,7 +189,7 @@ Expected: all pass.
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/components/TargetPresetBar.module.css
@@ -204,7 +204,7 @@ git commit -m "feat(mobile): compact TargetPresetBar in side-panel row"
 - Modify: `src/components/FeedbackCard.module.css:98-102`
 - Modify: `src/components/Toolbar.module.css:1-12`
 
-- [ ] **Step 1: Add mobile `.card` flex + compaction rules**
+- [x] **Step 1: Add mobile `.card` flex + compaction rules**
 
 The current FeedbackCard mobile media query (lines 98-102):
 
@@ -230,7 +230,7 @@ Replace it with:
 
 Notes: `flex: 1` grows the card to fill its half of the `.sidePanel` row (matching TargetPresetBar's `flex: 1`). `min-width: 0` allows shrinking inside the flex row. `width: auto` is removed — the flex item sizes itself.
 
-- [ ] **Step 2: Add `flex-shrink: 0` to Toolbar**
+- [x] **Step 2: Add `flex-shrink: 0` to Toolbar**
 
 In `src/components/Toolbar.module.css`, add `flex-shrink: 0;` to the `.toolbar` base rule (lines 1-12), e.g. after `z-index: 20;`:
 
@@ -252,7 +252,7 @@ In `src/components/Toolbar.module.css`, add `flex-shrink: 0;` to the `.toolbar` 
 
 This prevents the sticky toolbar from shrinking when `.page` becomes a height-constrained flex column on mobile. It is harmless on desktop.
 
-- [ ] **Step 3: Run tests + typecheck**
+- [x] **Step 3: Run tests + typecheck**
 
 Run: `npx vitest run src/__tests__/`
 Expected: all pass.
@@ -260,7 +260,7 @@ Expected: all pass.
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/components/FeedbackCard.module.css src/components/Toolbar.module.css
@@ -273,22 +273,22 @@ git commit -m "feat(mobile): compact FeedbackCard in row, prevent toolbar shrink
 
 **Files:** none
 
-- [ ] **Step 1: Typecheck**
+- [x] **Step 1: Typecheck**
 
 Run: `npx tsc --noEmit`
 Expected: no errors.
 
-- [ ] **Step 2: Full test suite**
+- [x] **Step 2: Full test suite**
 
 Run: `npm test`
 Expected: all test files pass, 0 failures.
 
-- [ ] **Step 3: Production build**
+- [x] **Step 3: Production build**
 
 Run: `npm run build`
 Expected: build succeeds, `dist/` produced.
 
-- [ ] **Step 4: Manual mobile check (browser DevTools)**
+- [x] **Step 4: Manual mobile check (browser DevTools)**
 
 Verify in the browser (Vite dev server or `dist/` build) with DevTools device emulation (e.g. iPhone SE 375×667):
 1. Entire page fits in one viewport — no vertical page scrollbar.
@@ -297,7 +297,7 @@ Verify in the browser (Vite dev server or `dist/` build) with DevTools device em
 4. Desktop viewport (>768px, e.g. 1280×800) is unchanged: TargetPresetBar left, FeedbackCard right, charts centered.
 5. Narrow screen (e.g. 320×568) still fits one screen; charts stay ≥120px (`.chartArea` min-height).
 
-- [ ] **Step 5: Final commit check**
+- [x] **Step 5: Final commit check**
 
 Run: `git status --short` and `git log --oneline -6`
 Expected: all work committed, clean status.

--- a/docs/superpowers/plans/2026-08-01-mobile-single-screen-layout.md
+++ b/docs/superpowers/plans/2026-08-01-mobile-single-screen-layout.md
@@ -1,0 +1,303 @@
+# 移动端一屏适配 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On mobile (`max-width: 768px`) constrain all UI within one viewport height (no page scroll): Toolbar fixed, TargetPresetBar + FeedbackCard side-by-side in one row, two charts flex-fill remaining height.
+
+**Architecture:** Fix the layout root cause — AnalysisPage root `<div>` becomes a flex column (`styles.page`) with `height: 100dvh; overflow: hidden` on mobile, so `.content`'s `flex: 1` finally works. The side panel becomes a horizontal flex row; charts lose their fixed 280px height and flex-fill. All changes are pure CSS except one JSX class addition. Desktop (>768px) layout is untouched.
+
+**Tech Stack:** React 18, CSS Modules, Vite, Vitest (jsdom — cannot test media queries; verification is existing tests + tsc + build + manual DevTools check).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-mobile-single-screen-layout-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/routes/AnalysisPage.tsx` — add `className={styles.page}` to root `<div>`
+- **Modify** `src/routes/AnalysisPage.module.css` — add `.page`; rework mobile media query (`.content`, `.sidePanel`, `.chartsColumn`, `.chartWrapper`)
+- **Modify** `src/components/TargetPresetBar.module.css` — mobile `.bar` flex + compaction
+- **Modify** `src/components/FeedbackCard.module.css` — mobile `.card` flex + compaction
+- **Modify** `src/components/Toolbar.module.css` — `.toolbar` `flex-shrink: 0`
+
+---
+
+### Task 1: Layout root — `.page` flex column + AnalysisPage mobile rules
+
+**Files:**
+- Modify: `src/routes/AnalysisPage.tsx:47`
+- Modify: `src/routes/AnalysisPage.module.css:108-118`
+
+- [ ] **Step 1: Add `.page` class to AnalysisPage root**
+
+In `src/routes/AnalysisPage.tsx`, change the root wrapper from a bare `<div>` to `<div className={styles.page}>`:
+
+```tsx
+  return (
+    <div className={styles.page}>
+      <Toolbar toolItems={toolItems} onToolClick={handleClickTool} />
+```
+
+`styles` is already imported (`import styles from './AnalysisPage.module.css'`).
+
+- [ ] **Step 2: Add `.page` base rule and rework the mobile media query**
+
+In `src/routes/AnalysisPage.module.css`, add a `.page` base rule right after `.content` (desktop: plain block, no effect). Current lines 1-6:
+
+```css
+.content {
+  flex: 1;
+  position: relative;
+  padding: 16px 20px;
+  width: 100%;
+}
+```
+
+Add after it:
+
+```css
+.page {
+  display: flex;
+  flex-direction: column;
+}
+```
+
+Then replace the entire existing mobile media query (currently lines 108-118):
+
+```css
+@media (max-width: 768px) {
+  .content {
+    padding: 14px;
+  }
+  .sidePanel {
+    position: static;
+    width: 100%;
+    margin-bottom: 14px;
+  }
+  .chartWrapper { height: 280px; }
+}
+```
+
+with:
+
+```css
+@media (max-width: 768px) {
+  .page {
+    height: 100dvh;
+    overflow: hidden;
+  }
+  .content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px;
+  }
+  .sidePanel {
+    position: static;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+  .chartsColumn {
+    flex: 1;
+    min-height: 0;
+  }
+  .chartWrapper {
+    flex: 1;
+    height: auto;
+    min-height: 0;
+    margin: 8px auto;
+  }
+}
+```
+
+Notes:
+- `.sidePanel` keeps `gap: 12px` from its base rule; the `margin-bottom: 14px` is removed because `.content`'s `gap: 12px` now handles vertical spacing.
+- `.chartWrapper` keeps its base `width: calc(100% - 20px)`; only height/flex change.
+- `.card` and `.chartsColumnCard` base rules already provide `flex: 1; min-height: 0` for the chart cards; `.chartArea` already has `flex: 1 1 auto; min-height: 120px`.
+
+- [ ] **Step 3: Run unit tests + typecheck**
+
+Run: `npx vitest run src/__tests__/`
+Expected: all existing tests pass (jsdom ignores CSS media queries; no test should change).
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/AnalysisPage.tsx src/routes/AnalysisPage.module.css
+git commit -m "feat(mobile): single-screen flex column layout for mobile"
+```
+
+---
+
+### Task 2: TargetPresetBar mobile compaction
+
+**Files:**
+- Modify: `src/components/TargetPresetBar.module.css:114-118`
+
+- [ ] **Step 1: Add mobile `.bar` flex + compaction rules**
+
+The current mobile media query (lines 114-118):
+
+```css
+@media (max-width: 768px) {
+  .vowels {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+```
+
+Replace it with:
+
+```css
+@media (max-width: 768px) {
+  .bar {
+    flex: 1;
+    min-width: 0;
+    padding: 10px;
+    gap: 10px;
+    max-height: none;
+  }
+  .vowels {
+    grid-template-columns: repeat(6, 1fr);
+  }
+  .bandLo,
+  .bandHi {
+    height: 20px;
+  }
+}
+```
+
+Notes:
+- `flex: 1` makes the bar grow to fill its half of the `.sidePanel` row (sibling FeedbackCard also has `flex: 1` → 50/50 split).
+- `max-height: none` overrides the base `max-height: calc(100vh - 88px)` (a desktop fixed-panel rule) so no internal scroll on mobile.
+- `min-width: 0` allows the bar to shrink below its content width inside the flex row.
+- Band input compaction reduces `.bandLo`/`.bandHi` height from 22px to 20px. Their base rule (lines 83-97) also contains `flex: 1; min-width: 0` which is preserved.
+
+- [ ] **Step 2: Run TargetPresetBar tests + typecheck**
+
+Run: `npx vitest run src/__tests__/TargetPresetBar.test.tsx src/__tests__/FeedbackCard.test.tsx`
+Expected: all pass.
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TargetPresetBar.module.css
+git commit -m "feat(mobile): compact TargetPresetBar in side-panel row"
+```
+
+---
+
+### Task 3: FeedbackCard mobile flex + compaction, Toolbar flex-shrink
+
+**Files:**
+- Modify: `src/components/FeedbackCard.module.css:98-102`
+- Modify: `src/components/Toolbar.module.css:1-12`
+
+- [ ] **Step 1: Add mobile `.card` flex + compaction rules**
+
+The current FeedbackCard mobile media query (lines 98-102):
+
+```css
+@media (max-width: 768px) {
+  .card {
+    width: auto;
+  }
+}
+```
+
+Replace it with:
+
+```css
+@media (max-width: 768px) {
+  .card {
+    flex: 1;
+    min-width: 0;
+    padding: 10px;
+  }
+}
+```
+
+Notes: `flex: 1` grows the card to fill its half of the `.sidePanel` row (matching TargetPresetBar's `flex: 1`). `min-width: 0` allows shrinking inside the flex row. `width: auto` is removed — the flex item sizes itself.
+
+- [ ] **Step 2: Add `flex-shrink: 0` to Toolbar**
+
+In `src/components/Toolbar.module.css`, add `flex-shrink: 0;` to the `.toolbar` base rule (lines 1-12), e.g. after `z-index: 20;`:
+
+```css
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 12px 24px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  flex-shrink: 0;
+}
+```
+
+This prevents the sticky toolbar from shrinking when `.page` becomes a height-constrained flex column on mobile. It is harmless on desktop.
+
+- [ ] **Step 3: Run tests + typecheck**
+
+Run: `npx vitest run src/__tests__/`
+Expected: all pass.
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/FeedbackCard.module.css src/components/Toolbar.module.css
+git commit -m "feat(mobile): compact FeedbackCard in row, prevent toolbar shrink"
+```
+
+---
+
+### Task 4: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: all test files pass, 0 failures.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds, `dist/` produced.
+
+- [ ] **Step 4: Manual mobile check (browser DevTools)**
+
+Verify in the browser (Vite dev server or `dist/` build) with DevTools device emulation (e.g. iPhone SE 375×667):
+1. Entire page fits in one viewport — no vertical page scrollbar.
+2. TargetPresetBar (left) and FeedbackCard (right) share the same row, roughly 50/50 width.
+3. F0 chart and Formant chart are stacked below, each flex-filling ~half the remaining height, both fully visible.
+4. Desktop viewport (>768px, e.g. 1280×800) is unchanged: TargetPresetBar left, FeedbackCard right, charts centered.
+5. Narrow screen (e.g. 320×568) still fits one screen; charts stay ≥120px (`.chartArea` min-height).
+
+- [ ] **Step 5: Final commit check**
+
+Run: `git status --short` and `git log --oneline -6`
+Expected: all work committed, clean status.

--- a/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
@@ -11,7 +11,7 @@
 - Zustand store（`src/store/appStore.ts`）持有 `frames`、`latestFrame`、`bands`、`stats`
 - 实时录音时每秒约 20 帧，每帧调用 `appendFrame` 更新 `latestFrame`
 - `TargetPresetBar` 显示目标区间预设并写入 `bands`
-- 页面布局：左侧 `TargetPresetBar`（绝对定位），中间图表列（`max-width: 900px` 居中），右侧空白
+- 页面布局：左侧 `TargetPresetBar`（绝对定位），中间图表列（`max-width: 900px` 居中）
 
 ## 数据模型（`src/types/index.ts` 新增）
 
@@ -38,15 +38,34 @@ export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null
 
 ```
 src/feedback/
-  hitRate.ts    // evaluateHitRate：边界判定
+  status.ts     // getFormantStatus：单值命中判定（数值行与汇总行共用）
+  hitRate.ts    // evaluateHitRate：汇总边界判定
   index.ts      // 注册表 FEEDBACK_EVALUATORS + useFeedback() hook
 ```
 
 未来新增反馈类型（如真假声判断）：新建 `src/feedback/falsetto.ts`，导出 evaluator，在 `index.ts` 的 `FEEDBACK_EVALUATORS` 数组追加即可。
 
+### getFormantStatus 逻辑（共享判定）
+
+单维度命中判定，数值行着色与汇总行提示共用同一规则（低于下限=low，高于上限=high，含边界=hit）：
+
+```ts
+export type FormantStatus = 'hit' | 'low' | 'high' | 'none'
+
+function getFormantStatus(
+  value: number | null | undefined,
+  range: [number, number],
+): FormantStatus {
+  if (value == null || !Number.isFinite(value)) return 'none'
+  if (value < range[0]) return 'low'
+  if (value > range[1]) return 'high'
+  return 'hit'
+}
+```
+
 ### evaluateHitRate 逻辑
 
-按区间边界判定（低于下限=偏低，高于上限=偏高）：
+按区间边界判定（复用 `getFormantStatus`）：
 
 ```ts
 const KEYS = ['f0', 'f1', 'f2'] as const
@@ -54,16 +73,17 @@ const KEYS = ['f0', 'f1', 'f2'] as const
 function evaluateHitRate({ latestFrame, bands }: FeedbackContext): FeedbackResult | null {
   if (!latestFrame) return null
   const hints: string[] = []
+  let hasData = false
   let allHit = true
   for (const k of KEYS) {
-    const v = latestFrame[k]
-    const range = bands[k].range
-    if (v == null || !Number.isFinite(v)) continue
-    if (v < range[0]) { allHit = false; hints.push(`${k.toUpperCase()}偏低`) }
-    else if (v > range[1]) { allHit = false; hints.push(`${k.toUpperCase()}偏高`) }
+    const status = getFormantStatus(latestFrame[k], bands[k].range)
+    if (status === 'none') continue
+    hasData = true
+    if (status === 'low') { allHit = false; hints.push(`${k.toUpperCase()}偏低`) }
+    else if (status === 'high') { allHit = false; hints.push(`${k.toUpperCase()}偏高`) }
   }
+  if (!hasData) return null
   if (allHit) return { id: 'hit-rate', label: '目标区间', status: 'hit', message: '完美' }
-  if (hints.length === 0) return null   // 无可比数据
   return { id: 'hit-rate', label: '目标区间', status: 'miss', message: hints.join(' ') }
 }
 ```
@@ -84,8 +104,8 @@ export function useFeedback(): FeedbackResult[] {
 
 `src/components/FeedbackCard.tsx` + `FeedbackCard.module.css`
 
-- 订阅 `useFeedback()`，渲染结果列表为行
-- 无任何结果时整个卡片不渲染
+- **常驻显示**：始终渲染（无数据时数值显示 `--`，汇总行显示 `—`），不返回 null
+- 订阅 `useAppStore` 的 `latestFrame` + `bands` 渲染 F0/F1/F2 实时数值行；订阅 `useFeedback()` 渲染汇总行
 
 ### 视觉（无图标，纯颜色/字体区分）
 
@@ -93,30 +113,39 @@ export function useFeedback(): FeedbackResult[] {
 ┌───────────────────────┐
 │ 实时反馈               │  ← header（加粗小字）
 ├───────────────────────┤
-│ 目标区间               │  ← 行标签（常规灰字 var(--text-soft)）
+│ F0    220 Hz          │  ← 数值行（命中=绿 / 偏低偏高=橙 / 无数据='--' 灰）
+│ F1    900 Hz          │
+│ F2   1200 Hz          │
+├───────────────────────┤
+│ 目标区间               │  ← 汇总行标签（常规灰字 var(--text-soft)）
 │ 完美                   │  ← hit: 绿色加粗 + 底部绿光晕脉冲
 │ 目标区间               │
 │ F0偏低  F2偏高         │  ← miss: 橙红色文字 + 加粗
-│ 真假声判断             │  ← idle: 标签正常，值显示 '—' 灰色，行半透明
-│ —                      │
 └───────────────────────┘
 ```
 
-状态区分：
+数值行（每行 `data-status` 驱动着色，不带文字提示）：
+- **hit**：值绿色（`var(--hit)`）+ `font-weight: 700`
+- **low / high**：值橙色（`var(--warn)`）+ `font-weight: 700`
+- **none**：值 `--` 灰色（`var(--text-mute)`）
+
+汇总行状态区分（原逻辑保留）：
 - **hit**：值文字绿色（`var(--hit)`）+ `font-weight: 700` + `@keyframes` 脉冲光晕（`box-shadow` 呼吸动画）
 - **miss**：值文字橙红色（`var(--warn)`）+ 加粗
-- **idle**：值 `—` 灰色（`var(--text-mute)`）+ 行整体半透明
 - 行标签统一灰色 `var(--text-soft)`
 
 ## 布局集成
 
-- `AnalysisPage.module.css`：新增右侧面板样式，与 `TargetPresetBar` 对称（`left: calc(50% + 466px)`），`width: 220px`
-- `AnalysisPage.tsx`：`<main>` 内加 `<FeedbackCard />`
-- 移动端（`max-width: 768px`）：与 `TargetPresetBar` 一致，`position: static` 堆叠在图表下方
+- `AnalysisPage.tsx`：`<main>` 内用 `<div className={styles.sidePanel}>` 包裹 `<TargetPresetBar />` + `<FeedbackCard />`（flex column）
+- `AnalysisPage.module.css`：新增 `.sidePanel`（`position: absolute; top: 16px; right: calc(50% + 466px); width: 220px; flex column; gap: 12px`），与图表列左侧对齐
+- `TargetPresetBar.module.css`：`.bar` 移除自身绝对定位（保留 `max-height` + `overflow-y: auto`），由 `.sidePanel` 定位
+- `FeedbackCard.module.css`：`.card` 移除绝对定位，改为静态、宽 100%
+- 移动端（`max-width: 768px`）：`.sidePanel` 变 `static`、宽 100%，两卡片堆叠在图表上方
 
 ## 测试
 
-- `src/__tests__/hitRate.test.ts`：evaluateHitRate 单元测试
+- `src/__tests__/hitRate.test.ts`：getFormantStatus + evaluateHitRate 单元测试
+  - getFormantStatus：hit / low / high / none / 边界（等于下限或上限 → hit）
   - 无 latestFrame → null
   - 全部命中 → `{ status: 'hit', message: '完美' }`
   - F0 低于下限 → miss + 'F0偏低'
@@ -125,10 +154,10 @@ export function useFeedback(): FeedbackResult[] {
   - 某值 null 时忽略该维度（不误报）
   - 全部值 null → null（无可比数据）
 - `src/__tests__/FeedbackCard.test.tsx`：组件渲染测试
-  - 无结果 → 不渲染
-  - hit 结果 → 显示"完美"绿色
-  - miss 结果 → 显示提示文字
-  - idle 结果 → 显示 '—'
+  - 无数据 → 常驻渲染，显示 header + 三个 `--` + 汇总行 `—`
+  - 有数据 → 显示 F0/F1/F2 具体 Hz 数值
+  - 数值行 `data-status` 正确（hit/low/high/none）
+  - 汇总行显示"完美"绿色 / 提示文字
 
 ## 不做的事（YAGNI）
 

--- a/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
@@ -1,0 +1,137 @@
+# 命中目标区间反馈系统设计
+
+## 目标
+
+为实时声音训练添加反馈效果：当用户发音（F0/F1/F2）命中目标区间时给出正向反馈；未命中时给出具体偏差提示（如"F0偏低""F2偏高"）。
+
+架构上采用**可扩展反馈系统**：每个反馈类型是一个独立评估器（evaluator），未来可添加"真假声判断"等新反馈类型，只需新增 evaluator 并在注册表注册，组件零改动。
+
+## 当前项目状态
+
+- Zustand store（`src/store/appStore.ts`）持有 `frames`、`latestFrame`、`bands`、`stats`
+- 实时录音时每秒约 20 帧，每帧调用 `appendFrame` 更新 `latestFrame`
+- `TargetPresetBar` 显示目标区间预设并写入 `bands`
+- 页面布局：左侧 `TargetPresetBar`（绝对定位），中间图表列（`max-width: 900px` 居中），右侧空白
+
+## 数据模型（`src/types/index.ts` 新增）
+
+```ts
+export type FeedbackStatus = 'hit' | 'miss' | 'idle'
+
+export interface FeedbackResult {
+  id: string               // 如 'hit-rate'
+  label: string            // 显示名，如 '目标区间'
+  status: FeedbackStatus   // hit=绿, miss=橙红, idle=灰
+  message: string          // '完美' 或 'F0偏低 F2偏高' 或 '—'
+}
+
+export interface FeedbackContext {
+  latestFrame: AnalysisFrame | null
+  bands: TargetBands
+}
+
+export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null
+// 返回 null = 该行不显示（如无数据）
+```
+
+## 评估器层（新目录 `src/feedback/`）
+
+```
+src/feedback/
+  hitRate.ts    // evaluateHitRate：边界判定
+  index.ts      // 注册表 FEEDBACK_EVALUATORS + useFeedback() hook
+```
+
+未来新增反馈类型（如真假声判断）：新建 `src/feedback/falsetto.ts`，导出 evaluator，在 `index.ts` 的 `FEEDBACK_EVALUATORS` 数组追加即可。
+
+### evaluateHitRate 逻辑
+
+按区间边界判定（低于下限=偏低，高于上限=偏高）：
+
+```ts
+const KEYS = ['f0', 'f1', 'f2'] as const
+
+function evaluateHitRate({ latestFrame, bands }: FeedbackContext): FeedbackResult | null {
+  if (!latestFrame) return null
+  const hints: string[] = []
+  let allHit = true
+  for (const k of KEYS) {
+    const v = latestFrame[k]
+    const range = bands[k].range
+    if (v == null || !Number.isFinite(v)) continue
+    if (v < range[0]) { allHit = false; hints.push(`${k.toUpperCase()}偏低`) }
+    else if (v > range[1]) { allHit = false; hints.push(`${k.toUpperCase()}偏高`) }
+  }
+  if (allHit) return { id: 'hit-rate', label: '目标区间', status: 'hit', message: '完美' }
+  if (hints.length === 0) return null   // 无可比数据
+  return { id: 'hit-rate', label: '目标区间', status: 'miss', message: hints.join(' ') }
+}
+```
+
+### useFeedback hook
+
+```ts
+export function useFeedback(): FeedbackResult[] {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
+  return FEEDBACK_EVALUATORS
+    .map(fn => fn({ latestFrame, bands }))
+    .filter((r): r is FeedbackResult => r !== null)
+}
+```
+
+## FeedbackCard 组件
+
+`src/components/FeedbackCard.tsx` + `FeedbackCard.module.css`
+
+- 订阅 `useFeedback()`，渲染结果列表为行
+- 无任何结果时整个卡片不渲染
+
+### 视觉（无图标，纯颜色/字体区分）
+
+```
+┌───────────────────────┐
+│ 实时反馈               │  ← header（加粗小字）
+├───────────────────────┤
+│ 目标区间               │  ← 行标签（常规灰字 var(--text-soft)）
+│ 完美                   │  ← hit: 绿色加粗 + 底部绿光晕脉冲
+│ 目标区间               │
+│ F0偏低  F2偏高         │  ← miss: 橙红色文字 + 加粗
+│ 真假声判断             │  ← idle: 标签正常，值显示 '—' 灰色，行半透明
+│ —                      │
+└───────────────────────┘
+```
+
+状态区分：
+- **hit**：值文字绿色（`var(--hit)`）+ `font-weight: 700` + `@keyframes` 脉冲光晕（`box-shadow` 呼吸动画）
+- **miss**：值文字橙红色（`var(--warn)`）+ 加粗
+- **idle**：值 `—` 灰色（`var(--text-mute)`）+ 行整体半透明
+- 行标签统一灰色 `var(--text-soft)`
+
+## 布局集成
+
+- `AnalysisPage.module.css`：新增右侧面板样式，与 `TargetPresetBar` 对称（`left: calc(50% + 466px)`），`width: 220px`
+- `AnalysisPage.tsx`：`<main>` 内加 `<FeedbackCard />`
+- 移动端（`max-width: 768px`）：与 `TargetPresetBar` 一致，`position: static` 堆叠在图表下方
+
+## 测试
+
+- `src/__tests__/hitRate.test.ts`：evaluateHitRate 单元测试
+  - 无 latestFrame → null
+  - 全部命中 → `{ status: 'hit', message: '完美' }`
+  - F0 低于下限 → miss + 'F0偏低'
+  - F2 高于上限 → miss + 'F2偏高'
+  - 多个偏离项合并
+  - 某值 null 时忽略该维度（不误报）
+  - 全部值 null → null（无可比数据）
+- `src/__tests__/FeedbackCard.test.tsx`：组件渲染测试
+  - 无结果 → 不渲染
+  - hit 结果 → 显示"完美"绿色
+  - miss 结果 → 显示提示文字
+  - idle 结果 → 显示 '—'
+
+## 不做的事（YAGNI）
+
+- 不添加语音/音效反馈
+- 不修改图表本身的命中高亮
+- 不实现真假声判断（仅预留扩展机制）

--- a/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-01-hit-target-feedback-design.md
@@ -28,10 +28,18 @@ export interface FeedbackResult {
 export interface FeedbackContext {
   latestFrame: AnalysisFrame | null
   bands: TargetBands
+  visible: FormantVisibility   // 当前图例可见性（必填——每个评估器都必须尊重可见性）
 }
 
 export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null
 // 返回 null = 该行不显示（如无数据）
+```
+
+新增共享可见性类型（`FormantSeries` 同时用于 store、图例与反馈）：
+
+```ts
+export type FormantSeries = 'f0' | 'f1' | 'f2'
+export type FormantVisibility = Record<FormantSeries, boolean>
 ```
 
 ## 评估器层（新目录 `src/feedback/`）
@@ -65,17 +73,18 @@ function getFormantStatus(
 
 ### evaluateHitRate 逻辑
 
-按区间边界判定（复用 `getFormantStatus`）：
+按区间边界判定（复用 `getFormantStatus`），**跳过图例隐藏的维度**（等价于该维度不存在，不计数 hasData）：
 
 ```ts
 const KEYS = ['f0', 'f1', 'f2'] as const
 
-function evaluateHitRate({ latestFrame, bands }: FeedbackContext): FeedbackResult | null {
+function evaluateHitRate({ latestFrame, bands, visible }: FeedbackContext): FeedbackResult | null {
   if (!latestFrame) return null
   const hints: string[] = []
   let hasData = false
   let allHit = true
   for (const k of KEYS) {
+    if (!visible[k]) continue
     const status = getFormantStatus(latestFrame[k], bands[k].range)
     if (status === 'none') continue
     hasData = true
@@ -94,18 +103,55 @@ function evaluateHitRate({ latestFrame, bands }: FeedbackContext): FeedbackResul
 export function useFeedback(): FeedbackResult[] {
   const latestFrame = useAppStore(s => s.latestFrame)
   const bands = useAppStore(s => s.bands)
+  const visible = useAppStore(s => s.formantVisible)
   return FEEDBACK_EVALUATORS
-    .map(fn => fn({ latestFrame, bands }))
+    .map(fn => fn({ latestFrame, bands, visible }))
     .filter((r): r is FeedbackResult => r !== null)
 }
 ```
+
+## 图例可见性（store 驱动）
+
+图例可见性提升至 Zustand store（与 `bands` 同级），遵循本仓库"命令驱动控制、数据经 store 流向组件"的核心原则：
+
+- **写入口唯一**：`AnalysisPage` 的图例按钮调用 `toggleFormantVisible(key)`，组件内部无 `useState` 副本
+- **读方共享**：`FormantChart`、`FeedbackCard`、`useFeedback` 均订阅 `formantVisible`
+- **联动规则**：用户在图例隐藏某 series 后：
+  - `FormantChart`：该 series 曲线数据清空、目标 markLine 移除（现有行为，来源从 prop 改为 store）
+  - `FeedbackCard` 数值行：隐藏项整行不渲染（含数值）
+  - 汇总行评估器：隐藏项不参与判定（如隐藏 f1/f2，则仅凭 f0 是否命中即可显示"完美"）
+  - 全部隐藏 → 无可评估维度 → 汇总行显示 idle `—`
+
+### store 变更（`src/store/appStore.ts`）
+
+```ts
+interface AppState {
+  config: AppConfig
+  bands: TargetBands
+  formantVisible: FormantVisibility   // 新增，与 bands 同级
+  frames: AnalysisFrame[]
+  latestFrame: AnalysisFrame | null
+  stats: AnalysisStats
+}
+
+interface AppActions {
+  // ...
+  toggleFormantVisible: (key: FormantSeries) => void
+}
+```
+
+- `initialState.formantVisible = { f0: true, f1: true, f2: true }`
+- `clearFrames()` 保留 `formantVisible`（与保留 config/bands 的语义一致）
+- `reset()` 恢复全部可见默认值
 
 ## FeedbackCard 组件
 
 `src/components/FeedbackCard.tsx` + `FeedbackCard.module.css`
 
 - **常驻显示**：始终渲染（无数据时数值显示 `--`，汇总行显示 `—`），不返回 null
-- 订阅 `useAppStore` 的 `latestFrame` + `bands` 渲染 F0/F1/F2 实时数值行；订阅 `useFeedback()` 渲染汇总行
+- 订阅 `useAppStore` 的 `latestFrame` + `bands` + `formantVisible` 渲染 F0/F1/F2 实时数值行；订阅 `useFeedback()` 渲染汇总行
+- **图例隐藏联动**：数值行按 `formantVisible` 过滤（`KEYS.filter(key => formantVisible[key])`），隐藏项整行不渲染
+- **零 props**：组件内部全部从 store 订阅，无需 AnalysisPage 传参
 
 ### 视觉（无图标，纯颜色/字体区分）
 
@@ -136,10 +182,11 @@ export function useFeedback(): FeedbackResult[] {
 
 ## 布局集成
 
-- `AnalysisPage.tsx`：`<main>` 内用 `<div className={styles.sidePanel}>` 包裹 `<TargetPresetBar />` + `<FeedbackCard />`（flex column）
+- `AnalysisPage.tsx`：`<main>` 内用 `<div className={styles.sidePanel}>` 包裹 `<TargetPresetBar />` + `<FeedbackCard />`（flex column）；图例按钮 `onClick={() => toggleFormantVisible(key)}`，`data-active={String(formantVisible[key])}`（替换原局部 `useState` 的 `handleToggleSeries`）
 - `AnalysisPage.module.css`：新增 `.sidePanel`（`position: absolute; top: 16px; right: calc(50% + 466px); width: 220px; flex column; gap: 12px`），与图表列左侧对齐
 - `TargetPresetBar.module.css`：`.bar` 移除自身绝对定位（保留 `max-height` + `overflow-y: auto`），由 `.sidePanel` 定位
 - `FeedbackCard.module.css`：`.card` 移除绝对定位，改为静态、宽 100%
+- `FormantChart.tsx`：移除 `seriesVisible` prop，改订阅 `useAppStore(s => s.formantVisible)`（`seriesVisibleRef` 同步逻辑保留）
 - 移动端（`max-width: 768px`）：`.sidePanel` 变 `static`、宽 100%，两卡片堆叠在图表上方
 
 ## 测试
@@ -153,11 +200,26 @@ export function useFeedback(): FeedbackResult[] {
   - 多个偏离项合并
   - 某值 null 时忽略该维度（不误报）
   - 全部值 null → null（无可比数据）
+  - **图例隐藏联动**：
+    - 隐藏偏离项（如 f1/f2 越界但 `visible` 隐藏）→ 仍返回 hit + '完美'
+    - 隐藏项不产生偏差提示（如 f0 越界、f1 越界但隐藏 → 仅 'F0偏低'）
+    - 全部隐藏 → 无可评估维度 → null
 - `src/__tests__/FeedbackCard.test.tsx`：组件渲染测试
   - 无数据 → 常驻渲染，显示 header + 三个 `--` + 汇总行 `—`
   - 有数据 → 显示 F0/F1/F2 具体 Hz 数值
   - 数值行 `data-status` 正确（hit/low/high/none）
   - 汇总行显示"完美"绿色 / 提示文字
+  - **图例隐藏联动**：store 隐藏 f1 → F1 数值行及 F1 Hz 不渲染，其余行正常
+- `src/__tests__/useFeedback.test.tsx`：hook 测试
+  - 无数据 → 空数组
+  - 全部命中 → hit + '完美'
+  - 响应 latestFrame 更新 → miss + 提示
+  - **图例隐藏联动**：store 隐藏 f2 且 f2 越界 → 仍返回 hit + '完美'
+- `src/__tests__/appStore.test.ts`：store 测试
+  - `formantVisible` 默认全可见
+  - `toggleFormantVisible` 翻转单项
+  - `clearFrames` 保留 `formantVisible`（与 config/bands 一致）
+  - `reset` 恢复全部可见
 
 ## 不做的事（YAGNI）
 

--- a/docs/superpowers/specs/2026-08-01-mobile-single-screen-layout-design.md
+++ b/docs/superpowers/specs/2026-08-01-mobile-single-screen-layout-design.md
@@ -1,0 +1,61 @@
+# 移动端一屏适配设计
+
+## 目标
+
+移动端（`max-width: 768px`）下，所有 UI 限制在同一屏高度内，无需向下滚动。当前移动端垂直堆叠 5 块内容（工具栏、目标区间、实时反馈、基频图、共振峰图），超出视口高度导致必须滚动才能看到共振峰谱。
+
+## 布局目标（≤768px）
+
+```
+┌──────────────────────────────┐
+│  Toolbar（固定高度）          │
+├──────────────────────────────┤
+│ 目标区间  │   实时反馈        │  ← 左右各半，同一行
+├──────────────────────────────┤
+│ 基频图（弹性高度）            │
+├──────────────────────────────┤
+│ 共振峰图（弹性高度）          │
+└──────────────────────────────┘
+```
+
+整页 `overflow: hidden`，两张图表 flex 弹性填满剩余空间，各占剩余高度约一半，宽度最大化。桌面端（>768px）布局完全不变。
+
+## 根因
+
+`#app` 是 flex column（`min-height: 100vh`），但 AnalysisPage 根 `<div>` 是无样式的 block 元素，`.content` 上的 `flex: 1` 实际不生效——页面高度完全由内容决定，必然溢出。图表卡 `height: 280px`（移动端固定值）进一步加剧溢出。
+
+## 改动清单
+
+### JSX（1 处）
+
+`src/routes/AnalysisPage.tsx`：根 `<div>` 添加 `className={styles.page}`。
+
+### CSS（均在 `@media (max-width: 768px)` 内）
+
+| 文件 | 选择器 | 改动 |
+|---|---|---|
+| `src/routes/AnalysisPage.module.css` | `.page`（新增） | `display:flex; flex-direction:column; height:100dvh; overflow:hidden` |
+| 同上 | `.content` | `flex:1; min-height:0; display:flex; flex-direction:column; gap:12px` |
+| 同上 | `.sidePanel` | 改 `flex-direction:row`（左右各半），保留 gap，`flex-shrink:0`，移除 `margin-bottom:14px` |
+| 同上 | `.chartsColumn` | `flex:1; min-height:0` |
+| 同上 | `.chartWrapper` | `flex:1; height:auto; min-height:0; margin:8px`（替换 `height:280px`） |
+| `src/components/TargetPresetBar.module.css` | `.bar` | `flex:1; min-width:0`；压紧：`padding:10px`、`gap:10px`、输入框 `height:20px` |
+| `src/components/FeedbackCard.module.css` | `.card` | `flex:1; min-width:0`；压紧：`padding:10px` |
+| `src/components/Toolbar.module.css` | `.toolbar` | `flex-shrink:0` |
+
+图表内部 `.card` 已有 `flex:1; min-height:0`，`.chartArea` 保持 `flex:1 1 auto; min-height:120px`（保证极矮屏下图表仍可用）。
+
+## 取舍与边界
+
+- 极矮屏（如横屏手机）下图表相应变矮，最低 120px。
+- 目标区间面板在移动端做轻微压紧（padding/字号/输入框高度微调），不改变任何业务逻辑。
+- 实时反馈面板不承载交互，仅压紧内边距。
+- ECharts 容器尺寸变化依赖 `window resize` 事件（现有 `useECharts` 已监听），无需新增逻辑。
+
+## 验证
+
+- jsdom 无法覆盖 CSS media query 布局，验证方式：
+  - 现有测试全绿（`npm test`）
+  - `npx tsc --noEmit`
+  - `npm run build`
+  - 浏览器 DevTools 移动端模拟（375×667 等）确认一屏无滚动、布局符合上图

--- a/src/__tests__/FeedbackCard.test.tsx
+++ b/src/__tests__/FeedbackCard.test.tsx
@@ -10,35 +10,54 @@ function setFrame(f0: number | null, f1: number | null, f2: number | null) {
   useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
 }
 
+const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+
 describe('FeedbackCard', () => {
   beforeEach(() => {
     useAppStore.getState().reset()
   })
 
-  it('renders nothing when no data', () => {
-    const { container } = render(<FeedbackCard />)
-    expect(container.firstChild).toBeNull()
+  it('renders header even with no data', () => {
+    render(<FeedbackCard />)
+    expect(screen.getByText('实时反馈')).toBeTruthy()
   })
 
-  it('renders hit result with 完美', () => {
-    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+  it('shows -- placeholders for values when no data', () => {
+    render(<FeedbackCard />)
+    expect(screen.getAllByText('--')).toHaveLength(3)
+  })
+
+  it('shows real-time F0/F1/F2 values in Hz', () => {
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText(`${mid(vowelA.f0[0], vowelA.f0[1])} Hz`)).toBeTruthy()
+    expect(screen.getByText(`${mid(vowelA.f1[0], vowelA.f1[1])} Hz`)).toBeTruthy()
+    expect(screen.getByText(`${mid(vowelA.f2[0], vowelA.f2[1])} Hz`)).toBeTruthy()
+  })
+
+  it('marks value rows with correct data-status', () => {
+    const midF0 = mid(vowelA.f0[0], vowelA.f0[1])
+    setFrame(midF0, vowelA.f1[0] - 50, vowelA.f2[1] + 100)
+    render(<FeedbackCard />)
+    const container = document.querySelector('aside')!
+    const rows = Array.from(container.querySelectorAll('[data-status]'))
+    const rowByLabel = (label: string) =>
+      rows.find(r => r.firstChild?.textContent === label) as HTMLElement
+    expect(rowByLabel('F0').dataset.status).toBe('hit')
+    expect(rowByLabel('F1').dataset.status).toBe('low')
+    expect(rowByLabel('F2').dataset.status).toBe('high')
+  })
+
+  it('renders summary row with 完美 when all hit', () => {
     setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
     render(<FeedbackCard />)
     expect(screen.getByText('目标区间')).toBeTruthy()
     expect(screen.getByText('完美')).toBeTruthy()
   })
 
-  it('renders miss result with deviation hints', () => {
-    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+  it('renders summary row with deviation hints when miss', () => {
     setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
     render(<FeedbackCard />)
     expect(screen.getByText('F2偏高')).toBeTruthy()
-  })
-
-  it('shows card header 实时反馈 when results exist', () => {
-    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
-    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
-    render(<FeedbackCard />)
-    expect(screen.getByText('实时反馈')).toBeTruthy()
   })
 })

--- a/src/__tests__/FeedbackCard.test.tsx
+++ b/src/__tests__/FeedbackCard.test.tsx
@@ -27,6 +27,12 @@ describe('FeedbackCard', () => {
     expect(screen.getAllByText('--')).toHaveLength(3)
   })
 
+  it('shows idle summary row with — when no data', () => {
+    render(<FeedbackCard />)
+    expect(screen.getByText('目标区间')).toBeTruthy()
+    expect(screen.getByText('—')).toBeTruthy()
+  })
+
   it('shows real-time F0/F1/F2 values in Hz', () => {
     setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
     render(<FeedbackCard />)

--- a/src/__tests__/FeedbackCard.test.tsx
+++ b/src/__tests__/FeedbackCard.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeedbackCard } from '../components/FeedbackCard'
+import { useAppStore } from '../store/appStore'
+import { VOWEL_PRESETS } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function setFrame(f0: number | null, f1: number | null, f2: number | null) {
+  useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
+}
+
+describe('FeedbackCard', () => {
+  beforeEach(() => {
+    useAppStore.getState().reset()
+  })
+
+  it('renders nothing when no data', () => {
+    const { container } = render(<FeedbackCard />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders hit result with 完美', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText('目标区间')).toBeTruthy()
+    expect(screen.getByText('完美')).toBeTruthy()
+  })
+
+  it('renders miss result with deviation hints', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    render(<FeedbackCard />)
+    expect(screen.getByText('F2偏高')).toBeTruthy()
+  })
+
+  it('shows card header 实时反馈 when results exist', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.getByText('实时反馈')).toBeTruthy()
+  })
+})

--- a/src/__tests__/FeedbackCard.test.tsx
+++ b/src/__tests__/FeedbackCard.test.tsx
@@ -66,4 +66,14 @@ describe('FeedbackCard', () => {
     render(<FeedbackCard />)
     expect(screen.getByText('F2偏高')).toBeTruthy()
   })
+
+  it('hides value row for hidden series', () => {
+    useAppStore.getState().toggleFormantVisible('f1')
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    render(<FeedbackCard />)
+    expect(screen.queryByText('F1')).toBeNull()
+    expect(screen.queryByText(`${mid(vowelA.f1[0], vowelA.f1[1])} Hz`)).toBeNull()
+    expect(screen.getByText('F0')).toBeTruthy()
+    expect(screen.getByText('F2')).toBeTruthy()
+  })
 })

--- a/src/__tests__/FormantChart.test.tsx
+++ b/src/__tests__/FormantChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import { FormantChart } from '../components/FormantChart'
 import { useAppStore } from '../store/appStore'
 
@@ -45,19 +45,22 @@ describe('FormantChart', () => {
 
   it('empties data and removes markLine for hidden series', () => {
     useAppStore.getState().setFrames(FRAMES)
-    render(<FormantChart seriesVisible={{ f0: true, f1: false, f2: true }} />)
+    useAppStore.getState().toggleFormantVisible('f1')
+    render(<FormantChart />)
     expect(seriesByName('F1').data).toEqual([])
     expect(seriesByName('F1').markLine).toBeUndefined()
     expect(seriesByName('F0').data).toHaveLength(2)
     expect(seriesByName('F2').data).toHaveLength(2)
   })
 
-  it('re-renders when seriesVisible prop changes', () => {
+  it('re-renders when store formantVisible changes', () => {
     useAppStore.getState().setFrames(FRAMES)
-    const { rerender } = render(<FormantChart />)
+    render(<FormantChart />)
     expect(seriesByName('F0').data).toHaveLength(2)
 
-    rerender(<FormantChart seriesVisible={{ f0: false, f1: true, f2: true }} />)
+    act(() => {
+      useAppStore.getState().toggleFormantVisible('f0')
+    })
 
     expect(seriesByName('F0').data).toEqual([])
     expect(seriesByName('F0').markLine).toBeUndefined()

--- a/src/__tests__/appStore.test.ts
+++ b/src/__tests__/appStore.test.ts
@@ -113,4 +113,43 @@ describe('appStore', () => {
       expect(state.latestFrame).toBeNull()
     })
   })
+
+  describe('formantVisible', () => {
+    it('defaults to all visible', () => {
+      const { formantVisible } = useAppStore.getState()
+      expect(formantVisible).toEqual({ f0: true, f1: true, f2: true })
+    })
+
+    it('toggleFormantVisible flips a single key', () => {
+      useAppStore.getState().toggleFormantVisible('f1')
+      const { formantVisible } = useAppStore.getState()
+      expect(formantVisible.f0).toBe(true)
+      expect(formantVisible.f1).toBe(false)
+      expect(formantVisible.f2).toBe(true)
+    })
+
+    it('toggleFormantVisible flips back', () => {
+      useAppStore.getState().toggleFormantVisible('f0')
+      useAppStore.getState().toggleFormantVisible('f0')
+      expect(useAppStore.getState().formantVisible.f0).toBe(true)
+    })
+  })
+
+  describe('clearFrames preserves formantVisible', () => {
+    it('keeps hidden state across clear', () => {
+      useAppStore.getState().toggleFormantVisible('f1')
+      useAppStore.getState().appendFrame(makeFrame({ time: 0.01, f0: 220 }))
+      useAppStore.getState().clearFrames()
+      expect(useAppStore.getState().formantVisible.f1).toBe(false)
+      expect(useAppStore.getState().frames).toEqual([])
+    })
+  })
+
+  describe('reset restores formantVisible', () => {
+    it('restores all visible', () => {
+      useAppStore.getState().toggleFormantVisible('f2')
+      useAppStore.getState().reset()
+      expect(useAppStore.getState().formantVisible).toEqual({ f0: true, f1: true, f2: true })
+    })
+  })
 })

--- a/src/__tests__/hitRate.test.ts
+++ b/src/__tests__/hitRate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateHitRate } from '../feedback/hitRate'
+import { VOWEL_PRESETS } from '../types'
+import type { FeedbackContext, AnalysisFrame } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function makeCtx(overrides: {
+  f0?: number | null
+  f1?: number | null
+  f2?: number | null
+}): FeedbackContext {
+  const frame: AnalysisFrame = {
+    time: 0.1,
+    f0: overrides.f0 ?? null,
+    f1: overrides.f1 ?? null,
+    f2: overrides.f2 ?? null,
+  }
+  return {
+    latestFrame: frame,
+    bands: {
+      f0: { range: vowelA.f0, color: '#10B981' },
+      f1: { range: vowelA.f1, color: '#3B82F6' },
+      f2: { range: vowelA.f2, color: '#F59E0B' },
+    },
+  }
+}
+
+describe('evaluateHitRate', () => {
+  it('returns null when no latest frame', () => {
+    const ctx = makeCtx({})
+    ctx.latestFrame = null
+    expect(evaluateHitRate(ctx)).toBeNull()
+  })
+
+  it('returns null when all formants are null', () => {
+    expect(evaluateHitRate(makeCtx({}))).toBeNull()
+  })
+
+  it('returns hit with "完美" when all in range', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    const result = evaluateHitRate(makeCtx({
+      f0: mid(vowelA.f0[0], vowelA.f0[1]),
+      f1: mid(vowelA.f1[0], vowelA.f1[1]),
+      f2: mid(vowelA.f2[0], vowelA.f2[1]),
+    }))
+    expect(result).toEqual({
+      id: 'hit-rate',
+      label: '目标区间',
+      status: 'hit',
+      message: '完美',
+    })
+  })
+
+  it('reports F0偏低 when below lower bound', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: vowelA.f0[0] - 50,
+      f1: (vowelA.f1[0] + vowelA.f1[1]) / 2,
+      f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toContain('F0偏低')
+  })
+
+  it('reports F2偏高 when above upper bound', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      f1: (vowelA.f1[0] + vowelA.f1[1]) / 2,
+      f2: vowelA.f2[1] + 100,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toContain('F2偏高')
+  })
+
+  it('merges multiple hints with space separator', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: vowelA.f0[0] - 50,
+      f1: vowelA.f1[1] + 200,
+      f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toBe('F0偏低 F1偏高')
+  })
+
+  it('ignores null formants without false negatives', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      f1: null,
+      f2: null,
+    }))
+    expect(result).toEqual({
+      id: 'hit-rate',
+      label: '目标区间',
+      status: 'hit',
+      message: '完美',
+    })
+  })
+})

--- a/src/__tests__/hitRate.test.ts
+++ b/src/__tests__/hitRate.test.ts
@@ -9,6 +9,7 @@ function makeCtx(overrides: {
   f0?: number | null
   f1?: number | null
   f2?: number | null
+  visible?: Partial<Record<'f0' | 'f1' | 'f2', boolean>>
 }): FeedbackContext {
   const frame: AnalysisFrame = {
     time: 0.1,
@@ -23,6 +24,7 @@ function makeCtx(overrides: {
       f1: { range: vowelA.f1, color: '#3B82F6' },
       f2: { range: vowelA.f2, color: '#F59E0B' },
     },
+    visible: { f0: true, f1: true, f2: true, ...overrides.visible },
   }
 }
 
@@ -94,5 +96,39 @@ describe('evaluateHitRate', () => {
       status: 'hit',
       message: '完美',
     })
+  })
+
+  it('ignores hidden out-of-range dims (returns hit)', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      f1: vowelA.f1[1] + 200,
+      f2: vowelA.f2[1] + 200,
+      visible: { f1: false, f2: false },
+    }))
+    expect(result).toEqual({
+      id: 'hit-rate',
+      label: '目标区间',
+      status: 'hit',
+      message: '完美',
+    })
+  })
+
+  it('hides deviation hints for hidden dims', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: vowelA.f0[0] - 50,
+      f1: vowelA.f1[1] + 200,
+      f2: (vowelA.f2[0] + vowelA.f2[1]) / 2,
+      visible: { f1: false },
+    }))
+    expect(result?.status).toBe('miss')
+    expect(result?.message).toBe('F0偏低')
+  })
+
+  it('returns null when all dims hidden', () => {
+    const result = evaluateHitRate(makeCtx({
+      f0: (vowelA.f0[0] + vowelA.f0[1]) / 2,
+      visible: { f0: false, f1: false, f2: false },
+    }))
+    expect(result).toBeNull()
   })
 })

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { getFormantStatus } from '../feedback/status'
+
+describe('getFormantStatus', () => {
+  it('returns hit when value is inside range', () => {
+    expect(getFormantStatus(300, [200, 400])).toBe('hit')
+  })
+
+  it('returns hit when value equals lower bound', () => {
+    expect(getFormantStatus(200, [200, 400])).toBe('hit')
+  })
+
+  it('returns hit when value equals upper bound', () => {
+    expect(getFormantStatus(400, [200, 400])).toBe('hit')
+  })
+
+  it('returns low when value is below lower bound', () => {
+    expect(getFormantStatus(100, [200, 400])).toBe('low')
+  })
+
+  it('returns high when value is above upper bound', () => {
+    expect(getFormantStatus(500, [200, 400])).toBe('high')
+  })
+
+  it('returns none for null', () => {
+    expect(getFormantStatus(null, [200, 400])).toBe('none')
+  })
+
+  it('returns none for undefined', () => {
+    expect(getFormantStatus(undefined, [200, 400])).toBe('none')
+  })
+
+  it('returns none for non-finite value', () => {
+    expect(getFormantStatus(NaN, [200, 400])).toBe('none')
+    expect(getFormantStatus(Infinity, [200, 400])).toBe('none')
+  })
+})

--- a/src/__tests__/useFeedback.test.tsx
+++ b/src/__tests__/useFeedback.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFeedback } from '../feedback'
+import { useAppStore } from '../store/appStore'
+import { VOWEL_PRESETS } from '../types'
+
+const vowelA = VOWEL_PRESETS['vowel-a']
+
+function setFrame(f0: number | null, f1: number | null, f2: number | null) {
+  useAppStore.getState().setFrames([{ time: 0.1, f0, f1, f2 }])
+}
+
+describe('useFeedback', () => {
+  beforeEach(() => {
+    useAppStore.getState().reset()
+  })
+
+  it('returns empty array with no data', () => {
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toEqual([])
+  })
+
+  it('returns hit result when all in range', () => {
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), mid(vowelA.f2[0], vowelA.f2[1]))
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].id).toBe('hit-rate')
+    expect(result.current[0].status).toBe('hit')
+    expect(result.current[0].message).toBe('完美')
+  })
+
+  it('reacts to latestFrame updates', () => {
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toEqual([])
+
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    act(() => {
+      setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    })
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].status).toBe('miss')
+    expect(result.current[0].message).toBe('F2偏高')
+  })
+})

--- a/src/__tests__/useFeedback.test.tsx
+++ b/src/__tests__/useFeedback.test.tsx
@@ -42,4 +42,16 @@ describe('useFeedback', () => {
     expect(result.current[0].status).toBe('miss')
     expect(result.current[0].message).toBe('F2偏高')
   })
+
+  it('respects store formantVisible (hidden out-of-range is ignored)', () => {
+    useAppStore.getState().toggleFormantVisible('f2')
+    const mid = (lo: number, hi: number) => Math.round((lo + hi) / 2)
+    act(() => {
+      setFrame(mid(vowelA.f0[0], vowelA.f0[1]), mid(vowelA.f1[0], vowelA.f1[1]), vowelA.f2[1] + 100)
+    })
+    const { result } = renderHook(() => useFeedback())
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].status).toBe('hit')
+    expect(result.current[0].message).toBe('完美')
+  })
 })

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -38,7 +38,6 @@
 .valueHit {
   color: var(--hit);
   border-radius: 4px;
-  animation: pulseGlow 1.6s ease-out infinite;
 }
 .valueWarn {
   color: var(--warn);
@@ -76,6 +75,10 @@
 .row[data-status="miss"] .value {
   color: var(--warn);
 }
+.row[data-status="hit"] .value {
+  color: var(--hit);
+  animation: pulseGlow 1.6s ease-out infinite;
+}
 
 @keyframes pulseGlow {
   0%, 100% {
@@ -87,7 +90,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .valueHit {
+  .row[data-status="hit"] .value {
     animation: none;
   }
 }

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -97,6 +97,8 @@
 
 @media (max-width: 768px) {
   .card {
-    width: auto;
+    flex: 1;
+    min-width: 0;
+    padding: 10px;
   }
 }

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -4,10 +4,6 @@
   border-radius: var(--radius);
   padding: 14px;
   box-shadow: var(--shadow-card);
-  position: absolute;
-  top: 16px;
-  left: calc(50% + 466px);
-  width: 220px;
 }
 .header {
   font-size: 12px;
@@ -98,8 +94,6 @@
 
 @media (max-width: 768px) {
   .card {
-    position: static;
-    width: 100%;
-    margin-bottom: 14px;
+    width: auto;
   }
 }

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -60,6 +60,12 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .valueHit {
+    animation: none;
+  }
+}
+
 @media (max-width: 768px) {
   .card {
     position: static;

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -1,0 +1,69 @@
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  box-shadow: var(--shadow-card);
+  position: absolute;
+  top: 16px;
+  left: calc(50% + 466px);
+  width: 220px;
+}
+.header {
+  font-size: 12px;
+  color: var(--text-soft);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+.list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px dashed var(--border);
+  padding-top: 12px;
+}
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.row[data-status="idle"] {
+  opacity: 0.55;
+}
+.label {
+  font-size: 11px;
+  color: var(--text-soft);
+}
+.value {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-mute);
+}
+.valueHit {
+  color: var(--hit);
+  border-radius: 4px;
+  animation: pulseGlow 1.6s ease-out infinite;
+}
+.row[data-status="miss"] .value {
+  color: var(--warn);
+}
+
+@keyframes pulseGlow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(16, 185, 129, 0);
+  }
+}
+
+@media (max-width: 768px) {
+  .card {
+    position: static;
+    width: 100%;
+    margin-bottom: 14px;
+  }
+}

--- a/src/components/FeedbackCard.module.css
+++ b/src/components/FeedbackCard.module.css
@@ -15,6 +15,41 @@
   font-weight: 600;
   letter-spacing: 0.3px;
 }
+.values {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px dashed var(--border);
+  margin-top: 12px;
+  padding-top: 12px;
+}
+.valueRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.valueLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-soft);
+  min-width: 20px;
+}
+.valueNum {
+  font-size: 15px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.valueHit {
+  color: var(--hit);
+  border-radius: 4px;
+  animation: pulseGlow 1.6s ease-out infinite;
+}
+.valueWarn {
+  color: var(--warn);
+}
+.valueMute {
+  color: var(--text-mute);
+}
 .list {
   list-style: none;
   margin: 12px 0 0;
@@ -41,11 +76,6 @@
   font-size: 15px;
   font-weight: 700;
   color: var(--text-mute);
-}
-.valueHit {
-  color: var(--hit);
-  border-radius: 4px;
-  animation: pulseGlow 1.6s ease-out infinite;
 }
 .row[data-status="miss"] .value {
   color: var(--warn);

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -5,7 +5,6 @@ import type { FormantStatus } from '../feedback/status'
 import styles from './FeedbackCard.module.css'
 
 const KEYS = ['f0', 'f1', 'f2'] as const
-type FormantKey = typeof KEYS[number]
 
 const STATUS_CLASS: Record<FormantStatus, string> = {
   hit: styles.valueHit,

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -21,13 +21,14 @@ function formatValue(value: number | null | undefined): string {
 export function FeedbackCard() {
   const latestFrame = useAppStore(s => s.latestFrame)
   const bands = useAppStore(s => s.bands)
+  const formantVisible = useAppStore(s => s.formantVisible)
   const results = useFeedback()
 
   return (
     <aside className={styles.card} aria-label="实时反馈">
       <div className={styles.header}>实时反馈</div>
       <div className={styles.values}>
-        {KEYS.map(key => {
+        {KEYS.filter(key => formantVisible[key]).map(key => {
           const status = getFormantStatus(latestFrame?.[key], bands[key].range)
           return (
             <div key={key} className={styles.valueRow} data-status={status}>

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -40,20 +40,27 @@ export function FeedbackCard() {
         })}
       </div>
       <ul className={styles.list}>
-        {results.map(result => (
-          <li
-            key={result.id}
-            className={styles.row}
-            data-status={result.status}
-          >
-            <span className={styles.label}>{result.label}</span>
-            <span
-              className={`${styles.value} ${result.status === 'hit' ? styles.valueHit : ''}`}
-            >
-              {result.message}
-            </span>
+        {results.length === 0 ? (
+          <li className={styles.row} data-status="idle">
+            <span className={styles.label}>目标区间</span>
+            <span className={styles.value}>—</span>
           </li>
-        ))}
+        ) : (
+          results.map(result => (
+            <li
+              key={result.id}
+              className={styles.row}
+              data-status={result.status}
+            >
+              <span className={styles.label}>{result.label}</span>
+              <span
+                className={`${styles.value} ${result.status === 'hit' ? styles.valueHit : ''}`}
+              >
+                {result.message}
+              </span>
+            </li>
+          ))
+        )}
       </ul>
     </aside>
   )

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -1,12 +1,45 @@
+import { useAppStore } from '../store/appStore'
 import { useFeedback } from '../feedback'
+import { getFormantStatus } from '../feedback/status'
+import type { FormantStatus } from '../feedback/status'
 import styles from './FeedbackCard.module.css'
 
+const KEYS = ['f0', 'f1', 'f2'] as const
+type FormantKey = typeof KEYS[number]
+
+const STATUS_CLASS: Record<FormantStatus, string> = {
+  hit: styles.valueHit,
+  low: styles.valueWarn,
+  high: styles.valueWarn,
+  none: styles.valueMute,
+}
+
+function formatValue(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '--'
+  return `${Math.round(value)} Hz`
+}
+
 export function FeedbackCard() {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
   const results = useFeedback()
-  if (results.length === 0) return null
+
   return (
     <aside className={styles.card} aria-label="实时反馈">
       <div className={styles.header}>实时反馈</div>
+      <div className={styles.values}>
+        {KEYS.map(key => {
+          const status = getFormantStatus(latestFrame?.[key], bands[key].range)
+          return (
+            <div key={key} className={styles.valueRow} data-status={status}>
+              <span className={styles.valueLabel}>{key.toUpperCase()}</span>
+              <span className={`${styles.valueNum} ${STATUS_CLASS[status]}`}>
+                {formatValue(latestFrame?.[key])}
+              </span>
+            </div>
+          )
+        })}
+      </div>
       <ul className={styles.list}>
         {results.map(result => (
           <li

--- a/src/components/FeedbackCard.tsx
+++ b/src/components/FeedbackCard.tsx
@@ -1,0 +1,28 @@
+import { useFeedback } from '../feedback'
+import styles from './FeedbackCard.module.css'
+
+export function FeedbackCard() {
+  const results = useFeedback()
+  if (results.length === 0) return null
+  return (
+    <aside className={styles.card} aria-label="实时反馈">
+      <div className={styles.header}>实时反馈</div>
+      <ul className={styles.list}>
+        {results.map(result => (
+          <li
+            key={result.id}
+            className={styles.row}
+            data-status={result.status}
+          >
+            <span className={styles.label}>{result.label}</span>
+            <span
+              className={`${styles.value} ${result.status === 'hit' ? styles.valueHit : ''}`}
+            >
+              {result.message}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/src/components/FormantChart.tsx
+++ b/src/components/FormantChart.tsx
@@ -41,12 +41,12 @@ function buildMarkLine(band: { range: [number, number]; color: string }, name: s
 interface FormantChartProps {
   cursorTime?: number
   onFrameClick?: (frame: AnalysisFrame) => void
-  seriesVisible?: Record<'f0' | 'f1' | 'f2', boolean>
 }
 
-export function FormantChart({ cursorTime = -1, onFrameClick, seriesVisible }: FormantChartProps) {
+export function FormantChart({ cursorTime = -1, onFrameClick }: FormantChartProps) {
   const frames = useAppStore(s => s.frames)
   const bands = useAppStore(s => s.bands)
+  const formantVisible = useAppStore(s => s.formantVisible)
   const { chartRef, setOption, getInstance } = useECharts()
   const rafRef = useRef<number | null>(null)
   const isLiveRef = useRef(false)
@@ -72,10 +72,10 @@ export function FormantChart({ cursorTime = -1, onFrameClick, seriesVisible }: F
   }, [frames.length])
 
   useEffect(() => {
-    seriesVisibleRef.current = { f0: true, f1: true, f2: true, ...seriesVisible }
+    seriesVisibleRef.current = formantVisible
     renderChart(frames, cursorTime, bands, isLiveRef.current, false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seriesVisible])
+  }, [formantVisible])
 
   // Chart click → find nearest frame
   useEffect(() => {

--- a/src/components/TargetPresetBar.module.css
+++ b/src/components/TargetPresetBar.module.css
@@ -112,7 +112,18 @@
 }
 
 @media (max-width: 768px) {
+  .bar {
+    flex: 1;
+    min-width: 0;
+    padding: 10px;
+    gap: 10px;
+    max-height: none;
+  }
   .vowels {
     grid-template-columns: repeat(6, 1fr);
+  }
+  .bandLo,
+  .bandHi {
+    height: 20px;
   }
 }

--- a/src/components/TargetPresetBar.module.css
+++ b/src/components/TargetPresetBar.module.css
@@ -7,10 +7,6 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  position: absolute;
-  top: 16px;
-  right: calc(50% + 466px);
-  width: 220px;
   max-height: calc(100vh - 88px);
   overflow-y: auto;
 }
@@ -116,13 +112,6 @@
 }
 
 @media (max-width: 768px) {
-  .bar {
-    position: static;
-    width: 100%;
-    max-height: none;
-    overflow: visible;
-    margin-bottom: 14px;
-  }
   .vowels {
     grid-template-columns: repeat(6, 1fr);
   }

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -9,6 +9,7 @@
   position: sticky;
   top: 0;
   z-index: 20;
+  flex-shrink: 0;
 }
 .brand {
   display: flex;

--- a/src/feedback/hitRate.ts
+++ b/src/feedback/hitRate.ts
@@ -1,0 +1,32 @@
+import type { FeedbackContext, FeedbackResult } from '../types'
+
+const KEYS = ['f0', 'f1', 'f2'] as const
+
+export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
+  const { latestFrame, bands } = ctx
+  if (!latestFrame) return null
+
+  const hints: string[] = []
+  let hasData = false
+  let allHit = true
+
+  for (const k of KEYS) {
+    const v = latestFrame[k]
+    const range = bands[k].range
+    if (v == null || !Number.isFinite(v)) continue
+    hasData = true
+    if (v < range[0]) {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏低`)
+    } else if (v > range[1]) {
+      allHit = false
+      hints.push(`${k.toUpperCase()}偏高`)
+    }
+  }
+
+  if (!hasData) return null
+  if (allHit) {
+    return { id: 'hit-rate', label: '目标区间', status: 'hit', message: '完美' }
+  }
+  return { id: 'hit-rate', label: '目标区间', status: 'miss', message: hints.join(' ') }
+}

--- a/src/feedback/hitRate.ts
+++ b/src/feedback/hitRate.ts
@@ -4,7 +4,7 @@ import { getFormantStatus } from './status'
 const KEYS = ['f0', 'f1', 'f2'] as const
 
 export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
-  const { latestFrame, bands } = ctx
+  const { latestFrame, bands, visible } = ctx
   if (!latestFrame) return null
 
   const hints: string[] = []
@@ -12,6 +12,7 @@ export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
   let allHit = true
 
   for (const k of KEYS) {
+    if (!visible[k]) continue
     const status = getFormantStatus(latestFrame[k], bands[k].range)
     if (status === 'none') continue
     hasData = true

--- a/src/feedback/hitRate.ts
+++ b/src/feedback/hitRate.ts
@@ -1,4 +1,5 @@
 import type { FeedbackContext, FeedbackResult } from '../types'
+import { getFormantStatus } from './status'
 
 const KEYS = ['f0', 'f1', 'f2'] as const
 
@@ -11,14 +12,13 @@ export function evaluateHitRate(ctx: FeedbackContext): FeedbackResult | null {
   let allHit = true
 
   for (const k of KEYS) {
-    const v = latestFrame[k]
-    const range = bands[k].range
-    if (v == null || !Number.isFinite(v)) continue
+    const status = getFormantStatus(latestFrame[k], bands[k].range)
+    if (status === 'none') continue
     hasData = true
-    if (v < range[0]) {
+    if (status === 'low') {
       allHit = false
       hints.push(`${k.toUpperCase()}偏低`)
-    } else if (v > range[1]) {
+    } else if (status === 'high') {
       allHit = false
       hints.push(`${k.toUpperCase()}偏高`)
     }

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -1,0 +1,15 @@
+import { useAppStore } from '../store/appStore'
+import type { FeedbackEvaluator, FeedbackResult } from '../types'
+import { evaluateHitRate } from './hitRate'
+
+export const FEEDBACK_EVALUATORS: FeedbackEvaluator[] = [
+  evaluateHitRate,
+]
+
+export function useFeedback(): FeedbackResult[] {
+  const latestFrame = useAppStore(s => s.latestFrame)
+  const bands = useAppStore(s => s.bands)
+  return FEEDBACK_EVALUATORS
+    .map(fn => fn({ latestFrame, bands }))
+    .filter((r): r is FeedbackResult => r !== null)
+}

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -9,7 +9,8 @@ export const FEEDBACK_EVALUATORS: FeedbackEvaluator[] = [
 export function useFeedback(): FeedbackResult[] {
   const latestFrame = useAppStore(s => s.latestFrame)
   const bands = useAppStore(s => s.bands)
+  const visible = useAppStore(s => s.formantVisible)
   return FEEDBACK_EVALUATORS
-    .map(fn => fn({ latestFrame, bands }))
+    .map(fn => fn({ latestFrame, bands, visible }))
     .filter((r): r is FeedbackResult => r !== null)
 }

--- a/src/feedback/status.ts
+++ b/src/feedback/status.ts
@@ -1,0 +1,11 @@
+export type FormantStatus = 'hit' | 'low' | 'high' | 'none'
+
+export function getFormantStatus(
+  value: number | null | undefined,
+  range: [number, number],
+): FormantStatus {
+  if (value == null || !Number.isFinite(value)) return 'none'
+  if (value < range[0]) return 'low'
+  if (value > range[1]) return 'high'
+  return 'hit'
+}

--- a/src/routes/AnalysisPage.module.css
+++ b/src/routes/AnalysisPage.module.css
@@ -4,6 +4,15 @@
   padding: 16px 20px;
   width: 100%;
 }
+.sidePanel {
+  position: absolute;
+  top: 16px;
+  right: calc(50% + 466px);
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
 .chartsColumn {
   display: flex;
   flex-direction: column;
@@ -99,6 +108,11 @@
 @media (max-width: 768px) {
   .content {
     padding: 14px;
+  }
+  .sidePanel {
+    position: static;
+    width: 100%;
+    margin-bottom: 14px;
   }
   .chartWrapper { height: 280px; }
 }

--- a/src/routes/AnalysisPage.module.css
+++ b/src/routes/AnalysisPage.module.css
@@ -111,6 +111,7 @@
 
 @media (max-width: 768px) {
   .page {
+    height: 100vh;
     height: 100dvh;
     overflow: hidden;
   }

--- a/src/routes/AnalysisPage.module.css
+++ b/src/routes/AnalysisPage.module.css
@@ -4,6 +4,10 @@
   padding: 16px 20px;
   width: 100%;
 }
+.page {
+  display: flex;
+  flex-direction: column;
+}
 .sidePanel {
   position: absolute;
   top: 16px;
@@ -106,13 +110,34 @@
 }
 
 @media (max-width: 768px) {
+  .page {
+    height: 100dvh;
+    overflow: hidden;
+  }
   .content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
     padding: 14px;
   }
   .sidePanel {
     position: static;
     width: 100%;
-    margin-bottom: 14px;
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+    flex-shrink: 0;
   }
-  .chartWrapper { height: 280px; }
+  .chartsColumn {
+    flex: 1;
+    min-height: 0;
+  }
+  .chartWrapper {
+    flex: 1;
+    height: auto;
+    min-height: 0;
+    margin: 8px auto;
+  }
 }

--- a/src/routes/AnalysisPage.tsx
+++ b/src/routes/AnalysisPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useToolbar } from '../hooks/useToolbar'
 import { Toolbar } from '../components/Toolbar'
 import { TargetPresetBar } from '../components/TargetPresetBar'
+import { FeedbackCard } from '../components/FeedbackCard'
 import { F0Chart } from '../components/F0Chart'
 import { FormantChart } from '../components/FormantChart'
 import { EmptyState } from '../components/EmptyState'
@@ -48,6 +49,7 @@ export function AnalysisPage() {
 
       <main className={styles.content}>
         <TargetPresetBar />
+        <FeedbackCard />
 
         <div className={styles.chartsColumn}>
           <section className={`${styles.card} ${styles.chartsColumnCard}`}>

--- a/src/routes/AnalysisPage.tsx
+++ b/src/routes/AnalysisPage.tsx
@@ -44,7 +44,7 @@ export function AnalysisPage() {
     )
 
   return (
-    <div>
+    <div className={styles.page}>
       <Toolbar toolItems={toolItems} onToolClick={handleClickTool} />
 
       <main className={styles.content}>

--- a/src/routes/AnalysisPage.tsx
+++ b/src/routes/AnalysisPage.tsx
@@ -48,8 +48,10 @@ export function AnalysisPage() {
       <Toolbar toolItems={toolItems} onToolClick={handleClickTool} />
 
       <main className={styles.content}>
-        <TargetPresetBar />
-        <FeedbackCard />
+        <div className={styles.sidePanel}>
+          <TargetPresetBar />
+          <FeedbackCard />
+        </div>
 
         <div className={styles.chartsColumn}>
           <section className={`${styles.card} ${styles.chartsColumnCard}`}>

--- a/src/routes/AnalysisPage.tsx
+++ b/src/routes/AnalysisPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useToolbar } from '../hooks/useToolbar'
+import { useAppStore } from '../store/appStore'
 import { Toolbar } from '../components/Toolbar'
 import { TargetPresetBar } from '../components/TargetPresetBar'
 import { FeedbackCard } from '../components/FeedbackCard'
@@ -11,12 +12,12 @@ import { HelpDrawer } from '../components/HelpDrawer'
 import { AboutModal } from '../components/AboutModal'
 import { TipWidget } from '../components/TipWidget'
 import { Toast } from '../components/Toast'
+import type { FormantSeries } from '../types'
 import styles from './AnalysisPage.module.css'
 
 const LEGEND_KEYS = ['f0', 'f1', 'f2'] as const
-type LegendKey = typeof LEGEND_KEYS[number]
 
-const COLORS: Record<LegendKey, string> = {
+const COLORS: Record<FormantSeries, string> = {
   f0: '#1F2937',
   f1: '#E23E57',
   f2: '#3B82F6',
@@ -26,15 +27,9 @@ export function AnalysisPage() {
   const [configOpen, setConfigOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
   const [aboutOpen, setAboutOpen] = useState(false)
-  const [seriesVisible, setSeriesVisible] = useState<Record<LegendKey, boolean>>({
-    f0: true,
-    f1: true,
-    f2: true,
-  })
 
-  const handleToggleSeries = (key: LegendKey) => {
-    setSeriesVisible(prev => ({ ...prev, [key]: !prev[key] }))
-  }
+  const formantVisible = useAppStore(s => s.formantVisible)
+  const toggleFormantVisible = useAppStore(s => s.toggleFormantVisible)
 
   const { toolItems, handleClickTool, hasData, cursorTime, fileInputRef, handleFileChange }
     = useToolbar(
@@ -80,8 +75,8 @@ export function AnalysisPage() {
                       key={key}
                       className={styles.legendItem}
                       data-key={key}
-                      data-active={String(seriesVisible[key])}
-                      onClick={() => handleToggleSeries(key)}
+                      data-active={String(formantVisible[key])}
+                      onClick={() => toggleFormantVisible(key)}
                     >
                       <i style={{ background: COLORS[key] }}></i>{key.toUpperCase()}
                     </button>
@@ -89,7 +84,7 @@ export function AnalysisPage() {
                 </div>
               </div>
               <div className={styles.chartArea}>
-                <FormantChart cursorTime={cursorTime} seriesVisible={seriesVisible} />
+                <FormantChart cursorTime={cursorTime} />
                 <EmptyState
                   title="曲线待生成"
                   description="录音或导入音频后显示共振峰曲线"

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { AppConfig, TargetBands, AnalysisFrame, AnalysisStats } from '../types'
+import type { AppConfig, TargetBands, AnalysisFrame, AnalysisStats, FormantSeries, FormantVisibility } from '../types'
 import { DEFAULT_CONFIG, VOWEL_PRESETS } from '../types'
 
 const WINDOW_FRAMES = 1000
@@ -10,6 +10,7 @@ interface AppState {
   frames: AnalysisFrame[]
   latestFrame: AnalysisFrame | null
   stats: AnalysisStats
+  formantVisible: FormantVisibility
 }
 
 interface AppActions {
@@ -18,6 +19,7 @@ interface AppActions {
   appendFrame: (frame: AnalysisFrame) => void
   setFrames: (frames: AnalysisFrame[]) => void
   clearFrames: () => void
+  toggleFormantVisible: (key: FormantSeries) => void
   reset: () => void
 }
 
@@ -36,6 +38,7 @@ const initialState: AppState = {
   frames: [],
   latestFrame: null,
   stats: { f0Mean: null, hitRate: null, duration: 0 },
+  formantVisible: { f0: true, f1: true, f2: true },
 }
 
 export const useAppStore = create<AppStore>((set) => ({
@@ -73,6 +76,10 @@ export const useAppStore = create<AppStore>((set) => ({
     latestFrame: null,
     stats: { f0Mean: null, hitRate: null, duration: 0 },
   }),
+
+  toggleFormantVisible: (key) => set((state) => ({
+    formantVisible: { ...state.formantVisible, [key]: !state.formantVisible[key] },
+  })),
 
   reset: () => set(initialState),
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,4 +80,5 @@ export interface FeedbackContext {
   bands: TargetBands
 }
 
+// null = 该行不显示（无可用数据）；status: 'idle' = 显示但置灰
 export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,9 +75,13 @@ export interface FeedbackResult {
   message: string
 }
 
+export type FormantSeries = 'f0' | 'f1' | 'f2'
+export type FormantVisibility = Record<FormantSeries, boolean>
+
 export interface FeedbackContext {
   latestFrame: AnalysisFrame | null
   bands: TargetBands
+  visible: FormantVisibility
 }
 
 // null = 该行不显示（无可用数据）；status: 'idle' = 显示但置灰

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,3 +65,19 @@ export interface AnalysisStats {
   hitRate: number | null
   duration: number
 }
+
+export type FeedbackStatus = 'hit' | 'miss' | 'idle'
+
+export interface FeedbackResult {
+  id: string
+  label: string
+  status: FeedbackStatus
+  message: string
+}
+
+export interface FeedbackContext {
+  latestFrame: AnalysisFrame | null
+  bands: TargetBands
+}
+
+export type FeedbackEvaluator = (ctx: FeedbackContext) => FeedbackResult | null


### PR DESCRIPTION
- **docs: add hit-target-feedback design spec**
- **feat(feedback): add feedback types**
- **docs(feedback): clarify null vs idle contract on FeedbackEvaluator**
- **feat(feedback): add evaluateHitRate evaluator**
- **feat(feedback): add useFeedback hook with evaluator registry**
- **docs: fix feedback wiring to spec (FeedbackCard subscribes internally)**
- **feat(feedback): add FeedbackCard component**
- **a11y(feedback): honor prefers-reduced-motion on pulse glow**
- **feat(feedback): wire FeedbackCard into AnalysisPage**
- **docs(feedback): update spec for always-on card, side placement, real-time values**
- **docs: add revision plan for always-on card with real-time values**
- **feat(feedback): add getFormantStatus shared evaluator**
- **refactor(feedback): reuse getFormantStatus in evaluateHitRate**
- **feat(feedback): always-on card with real-time F0/F1/F2 values**
- **refactor(feedback): drop unused FormantKey alias**
- **feat(feedback): stack FeedbackCard below TargetPresetBar in left panel**
- **fix(feedback): pulse animation only on summary hit row, not value rows**
- **docs: mark revision plan tasks 7-11 complete**
- **docs: add mobile single-screen layout design spec**
- **docs: add mobile single-screen layout implementation plan**
- **feat(mobile): single-screen flex column layout for mobile**
- **feat(mobile): compact TargetPresetBar in side-panel row**
- **feat(mobile): compact FeedbackCard in row, prevent toolbar shrink**
- **docs: mark mobile single-screen layout plan complete**
- **fix(mobile): add 100vh fallback for dvh support**
- **fix(feedback): show idle summary row with dash when no data**
- **docs(feedback): spec legend visibility via store-driven formantVisible**
- **docs(feedback): plan for store-driven formantVisible legend sync**
- **feat(feedback): add formantVisible to store with toggle action**
- **feat(feedback): respect formantVisible in evaluator and hook**
- **feat(feedback): filter FeedbackCard value rows by formantVisible**
- **feat(feedback): drive chart legend from store formantVisible**
- **docs(feedback): mark legend-visibility plan tasks complete**
